### PR TITLE
Add float to type

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -84,6 +84,8 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
     case value
     when String
       'string'
+    when Float
+      'float'
     when Integer
       'integer'
     when TrueClass, FalseClass


### PR DESCRIPTION
Nice gem 🙏 

I faced the following error when I ran rspec with enabling OPENAPI=1 option in my project. 
```
An error occurred in an `after(:suite)` hook.
Failure/Error: raise NotImplementedError, "type detection is not implemented for: #{value.inspect}"

NotImplementedError:
  type detection is not implemented for: 1.5
```

all green in my local 🍵 
```
➜ rspec-openapi git:(add-float-to-type) bundle exec rspec spec

Tables
  #index
    returns a list of tables
    does not return tables if unauthorized
  #show
    returns a table
    does not return a table if unauthorized
    does not return a table if not found
  #create
    returns a table
  #update
    returns a table
  #destroy
    returns a table

Finished in 0.06991 seconds (files took 1.96 seconds to load)
8 examples, 0 failures
```