### PR TITLE
add examples of response body

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -15,6 +15,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
                 content: {
                   normalize_content_type(record.response_content_type) => {
                     schema: build_property(record.response_body),
+                    example: record.response_body,
                   },
                 },
               },

--- a/spec/railsapp/doc/openapi.yaml
+++ b/spec/railsapp/doc/openapi.yaml
@@ -48,6 +48,16 @@ paths:
                       type: string
                     updated_at:
                       type: string
+              example:
+              - id: 1
+                name: access
+                description: 
+                database:
+                  id: 2
+                  name: production
+                storage_size: 12.3
+                created_at: '2020-06-22T18:19:22.398+09:00'
+                updated_at: '2020-06-22T18:19:22.398+09:00'
         '401':
           description: does not return tables if unauthorized
           content:
@@ -57,6 +67,8 @@ paths:
                 properties:
                   message:
                     type: string
+              example:
+                message: Unauthorized
     post:
       summary: 'tables #create'
       requestBody:
@@ -107,6 +119,16 @@ paths:
                     type: string
                   updated_at:
                     type: string
+              example:
+                id: 1
+                name: access
+                description: 
+                database:
+                  id: 2
+                  name: production
+                storage_size: 12.3
+                created_at: '2020-06-22T18:19:22.433+09:00'
+                updated_at: '2020-06-22T18:19:22.433+09:00'
   "/tables/{id}":
     get:
       summary: 'tables #show'
@@ -143,6 +165,16 @@ paths:
                     type: string
                   updated_at:
                     type: string
+              example:
+                id: 1
+                name: access
+                description: 
+                database:
+                  id: 2
+                  name: production
+                storage_size: 12.3
+                created_at: '2020-06-22T18:19:22.421+09:00'
+                updated_at: '2020-06-22T18:19:22.421+09:00'
         '401':
           description: does not return a table if unauthorized
           content:
@@ -152,6 +184,8 @@ paths:
                 properties:
                   message:
                     type: string
+              example:
+                message: Unauthorized
         '404':
           description: does not return a table if not found
           content:
@@ -161,6 +195,8 @@ paths:
                 properties:
                   message:
                     type: string
+              example:
+                message: not found
     patch:
       summary: 'tables #update'
       parameters:
@@ -196,6 +232,16 @@ paths:
                     type: string
                   updated_at:
                     type: string
+              example:
+                id: 1
+                name: access
+                description: 
+                database:
+                  id: 2
+                  name: production
+                storage_size: 12.3
+                created_at: '2020-06-22T18:19:22.440+09:00'
+                updated_at: '2020-06-22T18:19:22.440+09:00'
     delete:
       summary: 'tables #destroy'
       parameters:
@@ -231,3 +277,13 @@ paths:
                     type: string
                   updated_at:
                     type: string
+              example:
+                id: 1
+                name: access
+                description: 
+                database:
+                  id: 2
+                  name: production
+                storage_size: 12.3
+                created_at: '2020-06-22T18:19:22.444+09:00'
+                updated_at: '2020-06-22T18:19:22.444+09:00'


### PR DESCRIPTION
This is changes to save examples of response body in openapi schema

ref: https://swagger.io/docs/specification/adding-examples/

You can see them as response samples in docs:

![image](https://user-images.githubusercontent.com/116057/85271403-ba8b6800-b4b5-11ea-9705-c0523487d9e8.png)

But it might be a problem when you run this spec because the schema output becomes dynamic:

```sh
% OPENAPI=1 bundle exec rspec spec/requests/tables_spec.rb
...
An error occurred in an `after(:suite)` hook.
Failure/Error: expect(system('git', 'diff', '--exit-code', '--', RSpec::OpenAPI.path)).to eq(true)

  expected: true
       got: false

  (compared using ==)

  Diff:
  @@ -1,2 +1,2 @@
  -true
  +false
```