### PR TITLE
save examples of request parameters

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -15,7 +15,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       path: route.path.spec.to_s.delete_suffix('(.:format)'),
       path_params: request.path_parameters,
       query_params: request.query_parameters,
-      request_params: request.request_parameters,
+      request_params: raw_request_params(request),
       request_content_type: request.content_type,
       controller: route.requirements[:controller],
       action: route.requirements[:action],
@@ -34,5 +34,15 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       return route
     end
     raise "No route matched for #{request.request_method} #{request.path_info}"
+  end
+
+  # workaround to get real request parameters
+  # because ActionController::ParamsWrapper overwrites request_parameters
+  def raw_request_params(request)
+    tmp = request.request_parameters
+    request.delete_header('action_dispatch.request.request_parameters')
+    raw = request.request_parameters
+    request.set_header('action_dispatch.request.request_parameters', tmp)
+    raw
   end
 end

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -38,6 +38,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         in: 'path',
         required: true,
         schema: build_property(try_cast(value)),
+        example: try_cast(value),
       }
     end
 
@@ -46,6 +47,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         name: key.to_s,
         in: 'query',
         schema: build_property(try_cast(value)),
+        example: try_cast(value),
       }
     end
 
@@ -61,6 +63,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       content: {
         normalize_content_type(record.request_content_type) => {
           schema: build_property(record.request_params),
+          example: record.request_params,
         }
       }
     }

--- a/spec/railsapp/doc/openapi.yaml
+++ b/spec/railsapp/doc/openapi.yaml
@@ -58,8 +58,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-24T19:33:40.118+09:00'
-                updated_at: '2020-06-24T19:33:40.118+09:00'
+                created_at: '2020-06-24T21:36:50.312+09:00'
+                updated_at: '2020-06-24T21:36:50.312+09:00'
         '401':
           description: does not return tables if unauthorized
           content:
@@ -85,23 +85,10 @@ paths:
                   type: 'null'
                 database_id:
                   type: integer
-                table:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    description:
-                      type: 'null'
-                    database_id:
-                      type: integer
             example:
               name: k0kubun
               description: 
               database_id: 2
-              table:
-                name: k0kubun
-                description: 
-                database_id: 2
       responses:
         '201':
           description: returns a table
@@ -137,8 +124,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-24T19:33:40.238+09:00'
-                updated_at: '2020-06-24T19:33:40.238+09:00'
+                created_at: '2020-06-24T21:36:50.332+09:00'
+                updated_at: '2020-06-24T21:36:50.332+09:00'
   "/tables/{id}":
     get:
       summary: 'tables #show'
@@ -184,8 +171,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-24T19:33:40.181+09:00'
-                updated_at: '2020-06-24T19:33:40.181+09:00'
+                created_at: '2020-06-24T21:36:50.323+09:00'
+                updated_at: '2020-06-24T21:36:50.323+09:00'
         '401':
           description: does not return a table if unauthorized
           content:
@@ -252,8 +239,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-24T19:33:40.257+09:00'
-                updated_at: '2020-06-24T19:33:40.257+09:00'
+                created_at: '2020-06-24T21:36:50.341+09:00'
+                updated_at: '2020-06-24T21:36:50.341+09:00'
     delete:
       summary: 'tables #destroy'
       parameters:
@@ -298,5 +285,5 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-24T19:33:40.277+09:00'
-                updated_at: '2020-06-24T19:33:40.277+09:00'
+                created_at: '2020-06-24T21:36:50.346+09:00'
+                updated_at: '2020-06-24T21:36:50.346+09:00'

--- a/spec/railsapp/doc/openapi.yaml
+++ b/spec/railsapp/doc/openapi.yaml
@@ -15,10 +15,12 @@ paths:
         in: query
         schema:
           type: integer
+        example: 1
       - name: per
         in: query
         schema:
           type: integer
+        example: 10
       responses:
         '200':
           description: returns a list of tables
@@ -56,8 +58,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-22T18:19:22.398+09:00'
-                updated_at: '2020-06-22T18:19:22.398+09:00'
+                created_at: '2020-06-24T19:33:40.118+09:00'
+                updated_at: '2020-06-24T19:33:40.118+09:00'
         '401':
           description: does not return tables if unauthorized
           content:
@@ -92,6 +94,14 @@ paths:
                       type: 'null'
                     database_id:
                       type: integer
+            example:
+              name: k0kubun
+              description: 
+              database_id: 2
+              table:
+                name: k0kubun
+                description: 
+                database_id: 2
       responses:
         '201':
           description: returns a table
@@ -127,8 +137,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-22T18:19:22.433+09:00'
-                updated_at: '2020-06-22T18:19:22.433+09:00'
+                created_at: '2020-06-24T19:33:40.238+09:00'
+                updated_at: '2020-06-24T19:33:40.238+09:00'
   "/tables/{id}":
     get:
       summary: 'tables #show'
@@ -138,6 +148,7 @@ paths:
         required: true
         schema:
           type: integer
+        example: 1
       responses:
         '200':
           description: returns a table
@@ -173,8 +184,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-22T18:19:22.421+09:00'
-                updated_at: '2020-06-22T18:19:22.421+09:00'
+                created_at: '2020-06-24T19:33:40.181+09:00'
+                updated_at: '2020-06-24T19:33:40.181+09:00'
         '401':
           description: does not return a table if unauthorized
           content:
@@ -205,6 +216,7 @@ paths:
         required: true
         schema:
           type: integer
+        example: 1
       responses:
         '200':
           description: returns a table
@@ -240,8 +252,8 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-22T18:19:22.440+09:00'
-                updated_at: '2020-06-22T18:19:22.440+09:00'
+                created_at: '2020-06-24T19:33:40.257+09:00'
+                updated_at: '2020-06-24T19:33:40.257+09:00'
     delete:
       summary: 'tables #destroy'
       parameters:
@@ -250,6 +262,7 @@ paths:
         required: true
         schema:
           type: integer
+        example: 1
       responses:
         '200':
           description: returns a table
@@ -285,5 +298,5 @@ paths:
                   id: 2
                   name: production
                 storage_size: 12.3
-                created_at: '2020-06-22T18:19:22.444+09:00'
-                updated_at: '2020-06-22T18:19:22.444+09:00'
+                created_at: '2020-06-24T19:33:40.277+09:00'
+                updated_at: '2020-06-24T19:33:40.277+09:00'


### PR DESCRIPTION
same as #3 

also fixes an issue that request body changes: `{ name: 'foo' }` ->  `{ name: 'foo', table: { name: 'foo' } }`