### PR TITLE
Avoid JSON::ParserError when response body is no content

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -24,6 +24,13 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       summary = "#{request.method} #{request.path}"
     end
 
+    response_body =
+      begin
+        response.parsed_body
+      rescue JSON::ParserError
+        nil
+      end
+
     RSpec::OpenAPI::Record.new(
       method: request.request_method,
       path: path,
@@ -34,7 +41,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       summary: summary,
       description: RSpec::OpenAPI.description_builder.call(example),
       status: response.status,
-      response_body: response.parsed_body,
+      response_body: response_body,
       response_content_type: response.content_type,
     ).freeze
   end

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -2,6 +2,19 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
   # @param [RSpec::OpenAPI::Record] record
   # @return [Hash]
   def build(record)
+    response = {
+      description: record.description,
+    }
+
+    if record.response_body
+      response[:content] = {
+        normalize_content_type(record.response_content_type) => {
+          schema: build_property(record.response_body),
+          example: (record.response_body if example_enabled?),
+        }.compact,
+      }
+    end
+
     {
       paths: {
         normalize_path(record.path) => {
@@ -10,15 +23,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
             parameters: build_parameters(record),
             requestBody: build_request_body(record),
             responses: {
-              record.status.to_s => {
-                description: record.description,
-                content: {
-                  normalize_content_type(record.response_content_type) => {
-                    schema: build_property(record.response_body),
-                    example: (record.response_body if example_enabled?),
-                  }.compact,
-                },
-              },
+              record.status.to_s => response,
             },
           }.compact,
         },

--- a/spec/rails/app/controllers/tables_controller.rb
+++ b/spec/rails/app/controllers/tables_controller.rb
@@ -20,6 +20,10 @@ class TablesController < ApplicationController
   end
 
   def destroy
+    if params[:no_content]
+      return head :ok
+    end
+
     render json: find_table(params[:id])
   end
 

--- a/spec/rails/app/controllers/tables_controller.rb
+++ b/spec/rails/app/controllers/tables_controller.rb
@@ -21,7 +21,7 @@ class TablesController < ApplicationController
 
   def destroy
     if params[:no_content]
-      return head :ok
+      return head 202
     end
 
     render json: find_table(params[:id])

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -287,3 +287,15 @@ paths:
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
+        '202':
+          description: returns no content if specified
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                no_content:
+                  type: string
+            example:
+              no_content: 'true'

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -64,5 +64,10 @@ RSpec.describe 'Tables', type: :request do
       delete '/tables/1', headers: { authorization: 'k0kubun' }
       expect(response.status).to eq(200)
     end
+
+    it 'returns no content if specified' do
+      delete '/tables/1', headers: { authorization: 'k0kubun' }, params: { no_content: true }
+      expect(response.status).to eq(200)
+    end
   end
 end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Tables', type: :request do
 
     it 'returns no content if specified' do
       delete '/tables/1', headers: { authorization: 'k0kubun' }, params: { no_content: true }
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(202)
     end
   end
 end


### PR DESCRIPTION
If an api endpoint returns response with no content like `head :ok`,
`rspec-openapi` raises json parse error.

```ruby
      Failures:

         1) Tables #destroy returns no content if specified
            Failure/Error: response_body: response.parsed_body,

            JSON::ParserError:
              767: unexpected token at ''
            # ./lib/rspec/openapi/record_builder.rb:37:in `build'
            # ./lib/rspec/openapi/hooks.rb:12:in `block in <top (required)>'
```

This PR handles this parse error. It renders openapi spec without response body in this case.
