### PR TITLE
Fix float type

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -80,6 +80,10 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
 
   def build_property(value)
     property = { type: build_type(value) }
+
+    format = build_format(value)
+    property[:format] = format if format
+
     case value
     when Array
       property[:items] = build_property(value.first)
@@ -97,10 +101,10 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
     case value
     when String
       'string'
-    when Float
-      'float'
     when Integer
       'integer'
+    when Numeric
+      'number'
     when TrueClass, FalseClass
       'boolean'
     when Array
@@ -111,6 +115,15 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       'null'
     else
       raise NotImplementedError, "type detection is not implemented for: #{value.inspect}"
+    end
+  end
+
+  def build_format(value)
+    case value
+    when Float
+      'float'
+    else
+      nil
     end
   end
 

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -47,7 +47,8 @@ paths:
                         name:
                           type: string
                     storage_size:
-                      type: float
+                      type: number
+                      format: float
                     created_at:
                       type: string
                     updated_at:
@@ -115,7 +116,8 @@ paths:
                       name:
                         type: string
                   storage_size:
-                    type: float
+                    type: number
+                    format: float
                   created_at:
                     type: string
                   updated_at:
@@ -164,7 +166,8 @@ paths:
                       name:
                         type: string
                   storage_size:
-                    type: float
+                    type: number
+                    format: float
                   created_at:
                     type: string
                   updated_at:
@@ -234,7 +237,8 @@ paths:
                       name:
                         type: string
                   storage_size:
-                    type: float
+                    type: number
+                    format: float
                   created_at:
                     type: string
                   updated_at:
@@ -282,7 +286,8 @@ paths:
                       name:
                         type: string
                   storage_size:
-                    type: float
+                    type: number
+                    format: float
                   created_at:
                     type: string
                   updated_at:


### PR DESCRIPTION
This PR fixes float type error by implementing `build_format` method for `format` keyword.

When you load a schema file including 'type: float' in Swagger Editor, structural error occurs.

<img width="855" alt="スクリーンショット 2020-11-13 12 10 40" src="https://user-images.githubusercontent.com/25678257/99024420-e795ff80-25a9-11eb-90ca-9086c0580536.png">
<img width="761" alt="スクリーンショット 2020-11-13 12 10 46" src="https://user-images.githubusercontent.com/25678257/99024424-e8c72c80-25a9-11eb-91d5-b43bc6ef03ef.png">

In OAS3, `float` is not allowed for `type` and should be written as follows:
```yml
size:
  type: number
  format: float
```
https://swagger.io/docs/specification/data-models/data-types/