### PR TITLE
Add application version field

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -6,6 +6,7 @@ module RSpec::OpenAPI
   @comment = nil
   @enable_example = true
   @description_builder = -> (example) { example.description }
+  @application_version = '1.0.0'
 
   class << self
     attr_accessor :path, :comment, :enable_example, :description_builder

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -9,6 +9,6 @@ module RSpec::OpenAPI
   @application_version = '1.0.0'
 
   class << self
-    attr_accessor :path, :comment, :enable_example, :description_builder
+    attr_accessor :path, :comment, :enable_example, :description_builder, :application_version
   end
 end

--- a/lib/rspec/openapi/default_schema.rb
+++ b/lib/rspec/openapi/default_schema.rb
@@ -4,6 +4,7 @@ class << RSpec::OpenAPI::DefaultSchema = Object.new
       openapi: '3.0.3',
       info: {
         title: title,
+        version: RSpec::OpenAPI.application_version
       },
       paths: {},
     }.freeze

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -229,7 +229,7 @@ paths:
               image: !ruby/object:ActionDispatch::Http::UploadedFile
                 tempfile: !ruby/object:Tempfile
                   unlinked: true
-                  mode: 2562
+                  mode: 194
                   tmpfile: &1 !ruby/object:File {}
                   opts:
                     :perm: 384

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -6,6 +6,7 @@
 openapi: 3.0.3
 info:
   title: rspec-openapi
+  version: 1.0.0
 paths:
   "/tables":
     get:
@@ -228,7 +229,7 @@ paths:
               image: !ruby/object:ActionDispatch::Http::UploadedFile
                 tempfile: !ruby/object:Tempfile
                   unlinked: true
-                  mode: 194
+                  mode: 2562
                   tmpfile: &1 !ruby/object:File {}
                   opts:
                     :perm: 384

--- a/spec/roda/doc/openapi.yaml
+++ b/spec/roda/doc/openapi.yaml
@@ -2,6 +2,7 @@
 openapi: 3.0.3
 info:
   title: rspec-openapi
+  version: 1.0.0
 paths:
   "/roda":
     post:


### PR DESCRIPTION
Currently, the `version` field doesn't output to the generated YAML file and, as OpenAPI specification states, it is a required field. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#fixed-fields-1.

Also, when we try to import the YAML into Postman, it throws `format not recognized` because there is no `version` field on the output file.

So this PR let's the user specify an application version to be set in the YAML file and use `1.0.0` as default.