### PR TITLE
fix Multipart/form-data example object to filename

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -72,7 +72,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       content: {
         normalize_content_type(record.request_content_type) => {
           schema: build_property(record.request_params),
-          example: (record.request_params if example_enabled?),
+          example: (build_example(record.request_params) if example_enabled?),
         }.compact
       }
     }
@@ -124,6 +124,19 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
     rescue TypeError, ArgumentError
       value
     end
+  end
+
+  def build_example(value)
+    return nil if value.nil?
+    examples = {}
+    value.each do |key, v|
+      if v.is_a? ActionDispatch::Http::UploadedFile
+        examples[key] = v.original_filename
+      else
+        examples[key] = v
+      end
+    end
+    examples
   end
 
   def normalize_path(path)

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -226,18 +226,7 @@ paths:
                   type: string
                   format: binary
             example:
-              image: !ruby/object:ActionDispatch::Http::UploadedFile
-                tempfile: !ruby/object:Tempfile
-                  unlinked: true
-                  mode: 194
-                  tmpfile: &1 !ruby/object:File {}
-                  opts:
-                    :perm: 384
-                  delegate_dc_obj: *1
-                original_filename: test.png
-                content_type: image/png
-                headers: "Content-Disposition: form-data; name=\"image\"; filename=\"test.png\"\r\nContent-Type:
-                  image/png\r\nContent-Length: 71\r\n"
+              image: test.png
       responses:
         '200':
           description: returns a table


### PR DESCRIPTION
OpenApi v3 parse `&1 !ruby/object:File {}` to unknown tag.
thus, sample openapi.doc also can't open swagger-ui, swagger-editor, so on.
![スクリーンショット 2021-01-27 16 08 54](https://user-images.githubusercontent.com/18308639/105955675-00e31e00-60ba-11eb-8043-0d8c154feb54.png)

I fix put filename instead of ActionDispatch::Http::UploadedFile when create example.
I'm not sure to filename is enough params to example. you should fix as you like.
Is this implementation acceptable?

