### PR TITLE
RSpec converts YAML files to Hash before comparison

### DIFF
--- a/spec/rspec/rack_test_spec.rb
+++ b/spec/rspec/rack_test_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'fileutils'
+require 'yaml'
 
 RSpec.describe 'rack-test spec' do
   include SpecHelper
@@ -9,8 +10,9 @@ RSpec.describe 'rack-test spec' do
   end
 
   it 'generates the same spec/roda/doc/openapi.yaml' do
-    FileUtils.rm_f(openapi_path)
+    org_yaml = YAML.load(File.read(openapi_path))
     rspec 'spec/requests/roda_spec.rb', openapi: true
-    assert_run 'git', 'diff', '--exit-code', '--', openapi_path
+    new_yaml = YAML.load(File.read(openapi_path))
+    expect(new_yaml).to eq org_yaml
   end
 end

--- a/spec/rspec/rails_spec.rb
+++ b/spec/rspec/rails_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'yaml'
 
 RSpec.describe 'rails request spec' do
   include SpecHelper
@@ -8,8 +9,9 @@ RSpec.describe 'rails request spec' do
   end
 
   it 'generates the same spec/rails/doc/openapi.yaml' do
-    FileUtils.rm_f(openapi_path)
+    org_yaml = YAML.load(File.read(openapi_path))
     rspec 'spec/requests/rails_spec.rb', openapi: true
-    assert_run 'git', 'diff', '--exit-code', '--', openapi_path
+    new_yaml = YAML.load(File.read(openapi_path))
+    expect(new_yaml).to eq org_yaml
   end
 end


### PR DESCRIPTION
Hello, thank you for your nice tool.

I noticed the following failed test.
https://github.com/k0kubun/rspec-openapi/pull/22/checks?check_run_id=2051943034

I was able to reproduce it in my environment, too. The comparison of YAML files seems to be a bit buggy.

My idea is to convert the YAML files to Hash before the comparison.