### PR TITLE
Fix error of response example when Content-Disposition header is inline

### DIFF
--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -11,5 +11,6 @@ RSpec::OpenAPI::Record = Struct.new(
   :status,                # @param [Integer] - 200
   :response_body,         # @param [Object]  - {"status" => "ok"}
   :response_content_type, # @param [String]  - "application/json"
+  :response_content_disposition, # @param [String]  - "inline"
   keyword_init: true,
 )

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -47,6 +47,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       status: response.status,
       response_body: response_body,
       response_content_type: response.content_type,
+      response_content_disposition: response.header["Content-Disposition"],
     ).freeze
   end
 

--- a/spec/rails/app/controllers/images_controller.rb
+++ b/spec/rails/app/controllers/images_controller.rb
@@ -1,0 +1,7 @@
+class ImagesController < ApplicationController
+  def show
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+    QBoAAAAASUVORK5CYII='.unpack('m').first
+    send_data png, type: 'image/png', disposition: 'inline'
+  end
+end

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   defaults format: 'json' do
     resources :tables, only: [:index, :show, :create, :update, :destroy]
+    resources :images, only: [:show]
   end
 end

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -341,3 +341,23 @@ paths:
                   type: string
             example:
               no_content: 'true'
+  "/images/{id}":
+    get:
+      summary: show
+      tags:
+      - Image
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 1
+      responses:
+        '200':
+          description: returns a image payload
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -81,3 +81,12 @@ RSpec.describe 'Tables', type: :request do
     end
   end
 end
+
+RSpec.describe 'Images', type: :request do
+  describe '#payload' do
+    it 'returns a image payload' do
+      get '/images/1'
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
# The Issue

My action returns binary (Image) data using send_data with `disposition: "inline"` like this.

```ruby
class ImagesController < ActionController::Base
  protect_from_forgery

  def show
    path = "/file/to/image.png"
    image = File.open(path, "r")
    send_data image.read, type: "image/png", disposition: "inline"
  end
end
```

Generation was failed.

```ruby
require "rails_helper"

RSpec.describe "Images", type: :request do
  describe "show" do
    it "return 200" do
      get "/image/:id" do
        expect(response.status).to eq 200
      end
    end
  end
end
```

```
% export OEPNAPI=1
% bundle exec rspec
...
An error occurred in an `after(:suite)` hook.
Failure/Error: elsif o =~ /\n(?!\Z)/  # match \n except blank line at the end of string

ArgumentError:
  invalid byte sequence in UTF-8
# /file/to/rspec-openapi/lib/rspec/openapi/schema_file.rb:29:in `write'
# /file/to/rspec-openapi/lib/rspec/openapi/schema_file.rb:15:in `edit'
# /file/to/rspec-openapi/lib/rspec/openapi/hooks.rb:19:in `block in <main>'
```

# Solution

If `Content-Disposition` response header is presented, then `example` will not be shown.

# Other information

This PR's spec will fail before merging #23 or other fixing PRs to be modified.