### PR TITLE
Rails 6.1 deprecates content_type in favor of media_type

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -40,13 +40,13 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       path_params: raw_path_params(request),
       query_params: request.query_parameters,
       request_params: raw_request_params(request),
-      request_content_type: request.content_type,
+      request_content_type: request.media_type,
       summary: summary,
       tags: tags,
       description: RSpec::OpenAPI.description_builder.call(example),
       status: response.status,
       response_body: response_body,
-      response_content_type: response.content_type,
+      response_content_type: response.media_type,
       response_content_disposition: response.header["Content-Disposition"],
     ).freeze
   end


### PR DESCRIPTION
In Rails 6.0 there's a lot of "DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. "