### PR TITLE
Handle schema errors without failing the build

### DIFF
--- a/lib/rspec/openapi/hooks.rb
+++ b/lib/rspec/openapi/hooks.rb
@@ -6,6 +6,7 @@ require 'rspec/openapi/schema_file'
 require 'rspec/openapi/schema_merger'
 
 records = []
+records_errors = []
 
 RSpec.configuration.after(:each) do |example|
   if example.metadata[:type] == :request && example.metadata[:openapi] != false
@@ -19,7 +20,21 @@ RSpec.configuration.after(:suite) do
   RSpec::OpenAPI::SchemaFile.new(RSpec::OpenAPI.path).edit do |spec|
     RSpec::OpenAPI::SchemaMerger.reverse_merge!(spec, RSpec::OpenAPI::DefaultSchema.build(title))
     records.each do |record|
-      RSpec::OpenAPI::SchemaMerger.reverse_merge!(spec, RSpec::OpenAPI::SchemaBuilder.build(record))
+      begin
+        RSpec::OpenAPI::SchemaMerger.reverse_merge!(spec, RSpec::OpenAPI::SchemaBuilder.build(record))
+      rescue => e # e.g. SchemaBuilder raises a NotImplementedError
+        # NOTE: Don't fail the build
+        records_errors << [e, record]
+      end
     end
+  end
+  if records_errors.any?
+    error_message = <<~EOS
+      RSpec::OpenAPIGot errors building #{records_errors.size} requests
+      
+      #{records_errors.map {|e, record| "#{e.inspect}: #{record.inspect}" }.join("\n")}
+    EOS
+    colorizer = ::RSpec::Core::Formatters::ConsoleCodes
+    RSpec.configuration.reporter.message colorizer.wrap(error_message, :failure)
   end
 end

--- a/lib/rspec/openapi/hooks.rb
+++ b/lib/rspec/openapi/hooks.rb
@@ -30,7 +30,7 @@ RSpec.configuration.after(:suite) do
   end
   if records_errors.any?
     error_message = <<~EOS
-      RSpec::OpenAPIGot errors building #{records_errors.size} requests
+      RSpec::OpenAPI got errors building #{records_errors.size} requests
       
       #{records_errors.map {|e, record| "#{e.inspect}: #{record.inspect}" }.join("\n")}
     EOS


### PR DESCRIPTION
Feature: Don't crash the build :) Skip bad records.

One of our requests raises "NotImplementedError: type detection is not implemented for: #<JSONAPI::Exceptions::BadRequest: JSONAPI::Exceptions::BadRequest>>" which causes the whole build to fail.

The specific error is " request_params={"_parser_exception"=>#<JSONAPI::Exceptions::BadRequest: JSONAPI::Exceptions::BadRequest>},"

I was thinking it would be nice to use objects here instead of block scope, but that's for another day.

For example, then I could more easily write my own hook logic that didn't rely on the `example.metadata[:type] == :request`