### PR TITLE
FIX: NotImplementedError inherits from Exception (not StandardError)

### DIFF
--- a/lib/rspec/openapi/hooks.rb
+++ b/lib/rspec/openapi/hooks.rb
@@ -22,7 +22,7 @@ RSpec.configuration.after(:suite) do
     records.each do |record|
       begin
         RSpec::OpenAPI::SchemaMerger.reverse_merge!(spec, RSpec::OpenAPI::SchemaBuilder.build(record))
-      rescue => e # e.g. SchemaBuilder raises a NotImplementedError
+      rescue StandardError, NotImplementedError => e # e.g. SchemaBuilder raises a NotImplementedError
         # NOTE: Don't fail the build
         records_errors << [e, record]
       end


### PR DESCRIPTION
Sorry that I missed this distinction in the other PR.  I didn't thoroughly test it in my code :(

I think perhaps the SchemaBuilder should raise an rspec-openapi specific error, and have that inherit from StandardError. I'm happy to make that change instead of this one.