### PR TITLE
New feature: enable example types configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ EOS
 
 # Generate a custom description, given an RSpec example
 RSpec::OpenAPI.description_builder = -> (example) { example.description }
+
+# Change the example type(s) that will generate schema
+RSpec::OpenAPI.example_types = %i[request]
 ```
 
 ### How can I add information which can't be generated from RSpec?

--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -9,8 +9,9 @@ module RSpec::OpenAPI
   @application_version = '1.0.0'
   @request_headers = []
   @server_urls = []
+  @example_types = %i[request]
 
   class << self
-    attr_accessor :path, :comment, :enable_example, :description_builder, :application_version, :request_headers, :server_urls
+    attr_accessor :path, :comment, :enable_example, :description_builder, :application_version, :request_headers, :server_urls, :example_types
   end
 end

--- a/lib/rspec/openapi/hooks.rb
+++ b/lib/rspec/openapi/hooks.rb
@@ -9,7 +9,7 @@ records = []
 records_errors = []
 
 RSpec.configuration.after(:each) do |example|
-  if example.metadata[:type] == :request && example.metadata[:openapi] != false
+  if RSpec::OpenAPI.example_types.include?(example.metadata[:type]) && example.metadata[:openapi] != false
     record = RSpec::OpenAPI::RecordBuilder.build(self, example: example)
     records << record if record
   end
@@ -31,7 +31,7 @@ RSpec.configuration.after(:suite) do
   if records_errors.any?
     error_message = <<~EOS
       RSpec::OpenAPI got errors building #{records_errors.size} requests
-      
+
       #{records_errors.map {|e, record| "#{e.inspect}: #{record.inspect}" }.join("\n")}
     EOS
     colorizer = ::RSpec::Core::Formatters::ConsoleCodes


### PR DESCRIPTION
## Current Behaviour
All OpenAPI requests get run on the `type: :request`.

## Desired Behaviour
We would like to be able to run on one or more arbitrary types, e.g. `type: :flow`. This would mean changing file 
[hooks.rb](https://github.com/k0kubun/rspec-openapi/blob/master/lib/rspec/openapi/hooks.rb) to be configurable.

This will allow us to generate our schema.yaml from our flow specs as well as from our request specs.

Thank you for this wonderful gem!
