### PR TITLE
Able to assign proc to RSpec::OpenAPI.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ RSpec::OpenAPI.path = 'doc/schema.yaml'
 # Change the output type to JSON
 RSpec::OpenAPI.path = 'doc/schema.json'
 
+# Or generate multiple partial schema files, given an RSpec example
+RSpec::OpenAPI.path = -> (example) {
+  case example.file_path
+  when %r[spec/requests/api/v1/] then 'doc/openapi/v1.yaml'
+  when %r[spec/requests/api/v2/] then 'doc/openapi/v2.yaml'
+  else 'doc/openapi.yaml'
+  end
+}
+
 # Disable generating `example`
 RSpec::OpenAPI.enable_example = false
 


### PR DESCRIPTION
First of all, we greatly appreciate the work being done by the "rspec-openapi" project.

We would like to split the generated OpenAPI schema files and avoid the conflicts caused by joint editing of a single schema file.

To achieve this goal, we would like to see the schema files generated by "rspec-openapi" incorporated into the product to allow for the split generation per request spec files that we desire.

Therefore, we propose this change as a simple implementation to achieve our stated goal while maintaining backward compatibility.

Example:

```ruby
RSpec::OpenAPI.path = ->(example) {
  if %r[spec/requests/api/v1].match?(example.file_path)
    'doc/openapi/v1.yaml'
  elsif %r[spec/requests/api/v2].match?(example.file_path)
    'doc/openapi/v2.yaml'
  else
    'doc/openapi.yaml'
  end
}
```