### PR TITLE
Customizations via metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ RSpec.describe '/resources', type: :request do
 end
 ```
 
+## Customizations
+
+Some examples' attributes can be overwritten via RSpec metadata options. Example:
+
+```rb
+  describe 'GET /api/v1/posts', openapi: {
+    summary: 'list all posts',
+    description: 'list all posts ordered by pub_date',
+    tags: %w[v1 posts],
+  } do
+    # ...
+  end
+```
+
+**NOTE**: `description` key will override also the one provided by `RSpec::OpenAPI.description_builder` method.
+
 ## Links
 
 Existing RSpec plugins which have OpenAPI integration:

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -40,6 +40,8 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       headers_arr << [header, header_value] if header_value
     end
 
+    metadata_options = example.metadata[:openapi] || {}
+
     RSpec::OpenAPI::Record.new(
       method: request.request_method,
       path: path,
@@ -48,9 +50,9 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       request_params: raw_request_params(request),
       request_content_type: request.media_type,
       request_headers: request_headers,
-      summary: summary,
-      tags: tags,
-      description: RSpec::OpenAPI.description_builder.call(example),
+      summary: metadata_options[:summary] || summary,
+      tags: metadata_options[:tags] || tags,
+      description: metadata_options[:description] || RSpec::OpenAPI.description_builder.call(example),
       status: response.status,
       response_body: response_body,
       response_content_type: response.media_type,


### PR DESCRIPTION
Nice gem!

Can I propose you a small PR to allow more customizations via RSpec metadata?

Combined with the configuration:
`RSpec::OpenAPI.description_builder = -> (example) { example.metadata[:openapi_description] || example.description }`

A usage example could be:

```rb
  describe 'GET /api/v1/posts', {
    openapi_summary: 'list all posts',
    openapi_description: 'list all posts ordered by pub_date',
    openapi_tags: %w[v1 posts],
  } do
    # ...
  end
```

If you like the idea, I could update the specs and the README.