### PR TITLE
Handle Rails engine routes

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -19,8 +19,6 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     # Generate `path` and `summary` in a framework-friendly manner when possible
     if rails?
       route = find_rails_route(request)
-      raise "No route matched for #{request.request_method} #{request.path_info}" unless route
-
       path = route.path.spec.to_s.delete_suffix('(.:format)')
       summary = route.requirements[:action] || "#{request.method} #{path}"
       tags = [route.requirements[:controller]&.classify].compact
@@ -80,22 +78,16 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       request.path_info = File.join(request.script_name, request.path_info)
     end
 
-    found_route = nil
-    if app.respond_to? :routes
-      app.routes.router.recognize(request) do |route|
-        route_app = route.app
-        found_route ||=
-          if route_app.matches?(request)
-            if route_app.engine?
-              find_rails_route(request, app: route_app.rack_app, fix_path: false)
-            else
-              route
-            end
-          end
+    app.routes.router.recognize(request) do |route|
+      if route.app.matches?(request)
+        if route.app.engine?
+          return find_rails_route(request, app: route.app.app, fix_path: false)
+        else
+          return route
+        end
       end
     end
-
-    found_route
+    raise "No route matched for #{request.request_method} #{request.path_info}"
   end
 
   # :controller and :action always exist. :format is added when routes is configured as such.

--- a/spec/rails/config/application.rb
+++ b/spec/rails/config/application.rb
@@ -15,6 +15,8 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
+require_relative "../vendor/my_engine/lib/my_engine/engine"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount ::MyEngine::Engine => '/my_engine'
+
   defaults format: 'json' do
     resources :tables, only: [:index, :show, :create, :update, :destroy]
     resources :images, only: [:show]

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -606,6 +606,27 @@
           }
         }
       }
+    },
+    "/eng_route": {
+      "get": {
+        "summary": "GET /eng_route",
+        "tags": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "returns some content from the engine",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "AN ENGINE TEST"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -398,3 +398,15 @@ paths:
               schema:
                 type: string
               example: A TEST
+  "/eng_route":
+    get:
+      summary: GET /eng_route
+      tags: []
+      responses:
+        '200':
+          description: returns some content from the engine
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: AN ENGINE TEST

--- a/spec/rails/vendor/my_engine/config/routes.rb
+++ b/spec/rails/vendor/my_engine/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+MyEngine::Engine.routes.draw do
+  get '/eng_route' => ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['AN ENGINE TEST']] }
+end

--- a/spec/rails/vendor/my_engine/lib/my_engine/engine.rb
+++ b/spec/rails/vendor/my_engine/lib/my_engine/engine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module MyEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace MyEngine
+  end
+end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -115,3 +115,12 @@ RSpec.describe 'Extra routes', type: :request do
     end
   end
 end
+
+RSpec.describe 'Engine test', type: :request do
+  describe 'engine routes' do
+    it 'returns some content from the engine' do
+      get '/my_engine/eng_route'
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Let iterate all the recognized routes including the ones coming from Rails engines.

As reference, the relevant part of `action_dispatch`'s `recognize`:
https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/routing/route_set.rb#L881-L892

Fixes #37 