### PR TITLE
Fix some linter issues

### DIFF
--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -20,7 +20,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     if rails?
       route = find_rails_route(request)
       path = route.path.spec.to_s.delete_suffix('(.:format)')
-      summary = "#{route.requirements[:action]}"
+      summary = route.requirements[:action] || "#{request.method} #{path}"
       tags = [route.requirements[:controller]&.classify].compact
     else
       path = request.path

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -21,7 +21,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       route = find_rails_route(request)
       path = route.path.spec.to_s.delete_suffix('(.:format)')
       summary = "#{route.requirements[:action]}"
-      tags = [route.requirements[:controller].classify]
+      tags = [route.requirements[:controller]&.classify].compact
     else
       path = request.path
       summary = "#{request.method} #{request.path}"

--- a/spec/rails/config/routes.rb
+++ b/spec/rails/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   defaults format: 'json' do
     resources :tables, only: [:index, :show, :create, :update, :destroy]
     resources :images, only: [:show]
+
+    get '/test_block' => ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }
   end
 end

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -585,6 +585,27 @@
           }
         }
       }
+    },
+    "/test_block": {
+      "get": {
+        "summary": "GET /test_block",
+        "tags": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "returns the block content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "A TEST"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -386,3 +386,15 @@ paths:
               schema:
                 type: string
                 format: binary
+  "/test_block":
+    get:
+      summary: GET /test_block
+      tags: []
+      responses:
+        '200':
+          description: returns the block content
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: A TEST

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -106,3 +106,12 @@ RSpec.describe 'Images', type: :request do
     end
   end
 end
+
+RSpec.describe 'Extra routes', type: :request do
+  describe '#test_block' do
+    it 'returns the block content' do
+      get '/test_block'
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Hey :)

Checking with `@redocly/openapi-cli` linter I get some errors:
- `Expected type string but got null` related to the `tags` key when an empty value is exported;
- `Operation object summary must be non-empty string.` related to the `summary` key when an empty value is exported.

This PR is a proposal for minor improvements.

Please let me know your opinion.