### PR TITLE
Add how-to-require example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ and the schema file can be used as an input of [Swagger UI](https://github.com/s
 The following configurations are optional.
 
 ```rb
+require 'rspec/openapi'
+
 # Change the path to generate schema from `doc/openapi.yaml`
 RSpec::OpenAPI.path = 'doc/schema.yaml'
 


### PR DESCRIPTION
Hello, I appreciate this amazing gem. 

I am proposing a small improvement in the document.
I initially thought `require 'rspec-openapi'` since the gem name, but it is not.
