### PR TITLE
Implement smarter merge

### DIFF
--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -25,22 +25,15 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   # Also this needs to be aware of OpenAPI details unlike an ordinary deep_reverse_merge
   # because a Hash-like structure may be an array whose Hash elements have a key name.
   #
-  # TODO: Perform more intelligent merges like rerouting edits / merging types
   # TODO: Should we probably force-merge `summary` regardless of manual modifications?
   def deep_reverse_merge!(base, spec)
     spec.each do |key, value|
       if base[key].is_a?(Hash) && value.is_a?(Hash)
-        deep_reverse_merge!(base[key], value)
-      elsif !base.key?(key)
-        base[key] = value
-      elsif base[key].is_a?(Array) && value.is_a?(Array)
-        # parameters need to be merged as if `name` and `in` were the Hash keys.
-        if key == 'parameters'
-          base[key] |= value
-          base[key].uniq! { |param| param.slice('name', 'in') }
+        if !base[key].key?("$ref")
+          deep_reverse_merge!(base[key], value)
         end
       else
-        # no-op
+        base[key] = value
       end
     end
     base

--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -32,6 +32,14 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
         if !base[key].key?("$ref")
           deep_reverse_merge!(base[key], value)
         end
+      elsif base[key].is_a?(Array) && value.is_a?(Array)
+        # parameters need to be merged as if `name` and `in` were the Hash keys.
+        if key == 'parameters'
+          base[key] |= value
+          base[key].uniq! { |param| param.slice('name', 'in') }
+        else
+          base[key] = value
+        end
       else
         base[key] = value
       end

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -106,6 +106,46 @@
         },
         "parameters": [
           {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          },
+          {
+            "name": "per",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 10
+          },
+          {
+            "name": "X-Authorization-Token",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "token"
+          },
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "example": {
+              "name": "Example Table"
+            }
+          },
+          {
             "name": "filter[price]",
             "in": "query",
             "schema": {
@@ -228,7 +268,7 @@
             "schema": {
               "type": "integer"
             },
-            "example": 2
+            "example": 1
           }
         ],
         "responses": {

--- a/spec/rails/doc/openapi.json
+++ b/spec/rails/doc/openapi.json
@@ -41,7 +41,7 @@
             }
           },
           "200": {
-            "description": "with flat query parameters",
+            "description": "with different deep query parameters",
             "content": {
               "application/json": {
                 "schema": {
@@ -105,46 +105,6 @@
           }
         },
         "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            },
-            "example": 1
-          },
-          {
-            "name": "per",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            },
-            "example": 10
-          },
-          {
-            "name": "X-Authorization-Token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "example": "token"
-          },
-          {
-            "name": "filter[name]",
-            "in": "query",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              }
-            },
-            "example": {
-              "name": "Example Table"
-            }
-          },
           {
             "name": "filter[price]",
             "in": "query",
@@ -268,7 +228,7 @@
             "schema": {
               "type": "integer"
             },
-            "example": 1
+            "example": 2
           }
         ],
         "responses": {
@@ -406,7 +366,7 @@
               },
               "example": {
                 "nested": {
-                  "image": "#<ActionDispatch::Http::UploadedFile:0x00007fa723dec4a8>",
+                  "image": "test.png",
                   "caption": "Some caption"
                 }
               }

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -20,6 +20,25 @@ paths:
       tags:
       - Table
       parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+        example: 1
+      - name: per
+        in: query
+        schema:
+          type: integer
+        example: 10
+      - name: filter[name]
+        in: query
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+        example:
+          name: Example Table
       - name: filter[price]
         in: query
         schema:
@@ -29,6 +48,12 @@ paths:
               type: string
         example:
           price: '0'
+      - name: X-Authorization-Token
+        in: header
+        required: true
+        schema:
+          type: string
+        example: token
       responses:
         '200':
           description: with different deep query parameters
@@ -155,7 +180,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 2
+        example: 1
       responses:
         '200':
           description: returns a table

--- a/spec/rails/doc/openapi.yaml
+++ b/spec/rails/doc/openapi.yaml
@@ -20,25 +20,6 @@ paths:
       tags:
       - Table
       parameters:
-      - name: page
-        in: query
-        schema:
-          type: integer
-        example: 1
-      - name: per
-        in: query
-        schema:
-          type: integer
-        example: 10
-      - name: filter[name]
-        in: query
-        schema:
-          type: object
-          properties:
-            name:
-              type: string
-        example:
-          name: Example Table
       - name: filter[price]
         in: query
         schema:
@@ -48,15 +29,9 @@ paths:
               type: string
         example:
           price: '0'
-      - name: X-Authorization-Token
-        in: header
-        required: true
-        schema:
-          type: string
-        example: token
       responses:
         '200':
-          description: returns a list of tables
+          description: with different deep query parameters
           content:
             application/json:
               schema:
@@ -93,7 +68,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample:
+                null_sample: 
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -165,7 +140,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample:
+                null_sample: 
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -180,7 +155,7 @@ paths:
         required: true
         schema:
           type: integer
-        example: 1
+        example: 2
       responses:
         '200':
           description: returns a table
@@ -218,7 +193,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample:
+                null_sample: 
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -310,7 +285,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample:
+                null_sample: 
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'
@@ -362,7 +337,7 @@ paths:
                 database:
                   id: 2
                   name: production
-                null_sample:
+                null_sample: 
                 storage_size: 12.3
                 created_at: '2020-07-17T00:00:00+00:00'
                 updated_at: '2020-07-17T00:00:00+00:00'

--- a/spec/rspec/schema_merger/base.json
+++ b/spec/rspec/schema_merger/base.json
@@ -12,6 +12,17 @@
         "tags": [
           "Table"
         ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          }
+        ],
         "responses": {
           "200": {
             "description": "foo",

--- a/spec/rspec/schema_merger/base.json
+++ b/spec/rspec/schema_merger/base.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "My API",
+    "version": "1.0.0"
+  },
+  "servers": [],
+  "paths": {
+    "/tables": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Table"
+        ],
+        "responses": {
+          "200": {
+            "description": "foo",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Table"
+                },
+                "example": [
+                  {
+                    "id": 1,
+                    "name": "THIS SHOULD BE UPDATED"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Table": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/rspec/schema_merger/expected.json
+++ b/spec/rspec/schema_merger/expected.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "My API",
+    "version": "1.0.0"
+  },
+  "servers": [],
+  "paths": {
+    "/tables": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Table"
+        ],
+        "responses": {
+          "200": {
+            "description": "foo",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Table"
+                },
+                "example": [
+                  {
+                    "id": 9999,
+                    "name": "UPDATED"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Table": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/rspec/schema_merger/expected.json
+++ b/spec/rspec/schema_merger/expected.json
@@ -12,6 +12,17 @@
         "tags": [
           "Table"
         ],
+        "parameters": [
+          {
+            "name": "foo_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 9999
+          }
+        ],
         "responses": {
           "200": {
             "description": "foo",
@@ -29,8 +40,7 @@
               }
             }
           }
-        },
-        "parameters": []
+        }
       }
     }
   },

--- a/spec/rspec/schema_merger/input.json
+++ b/spec/rspec/schema_merger/input.json
@@ -1,0 +1,39 @@
+{
+  "paths": {
+    "/tables": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Table"
+        ],
+        "responses": {
+          "200": {
+            "description": "foo",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "id": 9999,
+                    "name": "UPDATED"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": []
+      }
+    }
+  }
+}

--- a/spec/rspec/schema_merger/input.json
+++ b/spec/rspec/schema_merger/input.json
@@ -6,6 +6,17 @@
         "tags": [
           "Table"
         ],
+        "parameters": [
+          {
+            "name": "foo_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 9999
+          }
+        ],
         "responses": {
           "200": {
             "description": "foo",
@@ -31,8 +42,7 @@
               }
             }
           }
-        },
-        "parameters": []
+        }
       }
     }
   }

--- a/spec/rspec/schema_merger/schema_merger_spec.rb
+++ b/spec/rspec/schema_merger/schema_merger_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'json'
+require "rspec/openapi/schema_merger"
+
+RSpec.describe "SchemaMerger" do
+  include SpecHelper
+
+  let(:base_path) do
+    File.expand_path('spec/rspec/schema_merger/base.json', repo_root)
+  end
+
+  let(:input_path) do
+    File.expand_path('spec/rspec/schema_merger/input.json', repo_root)
+  end
+
+  let(:expected_path) do
+    File.expand_path('spec/rspec/schema_merger/expected.json', repo_root)
+  end
+
+  it "overwrite the supported key, but leaves the unsupported keys" do
+    base_json = JSON.load(File.read(base_path))
+    input_json = JSON.load(File.read(input_path))
+    res = RSpec::OpenAPI::SchemaMerger.reverse_merge!(base_json, input_json)
+    expected_json = JSON.load(File.read(expected_path))
+    expect(res).to eq(expected_json)
+  end
+end


### PR DESCRIPTION
Closes #48 

This attempts to implement the behavior described in 
> everything under the path/method should be erased while leaving keys that rspec-openapi cannot update as is,
> and then changes generated by rspec-openapi should be added to it.
