### PR TITLE
Add the version constraint for actionpack

### DIFF
--- a/rspec-openapi.gemspec
+++ b/rspec-openapi.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'actionpack'
+  spec.add_dependency 'actionpack', '>= 6.0.0'
   spec.add_dependency 'rspec'
 end

--- a/rspec-openapi.gemspec
+++ b/rspec-openapi.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'actionpack', '>= 6.0.0'
+  spec.add_dependency 'actionpack', '>= 5.2.0'
   spec.add_dependency 'rspec'
 end


### PR DESCRIPTION
https://github.com/k0kubun/rspec-openapi/pull/38 introduced the check whether the route comes from Rails with `route.app.engine?`.

However, the method `engine?` was added in [this commit](https://github.com/rails/rails/pull/22435/commits/b50e88ebdf375cf81ad63586ce4599979262f975), and this is available since Rails 5.2.

So, adding the version constraint might make sense.

Note Rails 5.2 reached EOL, which means patches against
severe security issues will not be available, so I added `>= 6.0.0` instead of `>= 5.2.0`.