### PR TITLE
Accept empty array.

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -110,7 +110,11 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
 
     case value
     when Array
-      property[:items] = build_property(value.first)
+      if value.empty?
+        property[:items] = {} # unknown
+      else
+        property[:items] = build_property(value.first)
+      end
     when Hash
       property[:properties] = {}.tap do |properties|
         value.each do |key, v|

--- a/spec/rails/app/controllers/tables_controller.rb
+++ b/spec/rails/app/controllers/tables_controller.rb
@@ -4,7 +4,7 @@ class TablesController < ApplicationController
   before_action :authenticate
 
   def index
-    render json: [find_table]
+    render json: find_tables
   end
 
   def show
@@ -33,6 +33,12 @@ class TablesController < ApplicationController
     if request.headers[:authorization] != APIKEY
       render json: { message: 'Unauthorized' }, status: 401
     end
+  end
+
+  def find_tables
+    return [] if params.dig(:filter, :name) == 'Never Match'
+
+    [find_table]
   end
 
   def find_table(id = nil)

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe 'Tables', type: :request do
       end
     end
 
+    it 'can return an empty array' do
+      get '/tables', params: { filter: { "name" => "Never Match" } }, headers: { authorization: 'k0kubun' }
+      expect(response.status).to eq(200)
+    end
+
     it 'has a request spec which does not make any request' do
       expect(request).to eq(nil)
     end


### PR DESCRIPTION
## Current Behaviour

When generating a schema with a response with an empty array, the item property is marked as nullable.

```yml
responses:
  '200':
    content:
      application/json:
        schema:
          type: array
          items:
            type: object
            properties:
              id:
                type: integer
              ...
            nullable: true
```

## Desired Behaviour

Should generate schema of typed as an array with the unknown property rather than nullable for the array itself.
Unknown property is expressed as `properties: {}` based on OAS 3.0.

reference: https://swagger.io/docs/specification/data-models/data-types/#array

When combined with other RSpec examples has a response with an array filled with any items, then generated schema should be merged correctly.

Thank you for this beautiful gem!