### PR TITLE
Use super_diff to make a tiny diff easily spottable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem 'rails', ENV['RAILS_VERSION'] || '6.0.3.2'
 gem 'roda'
 gem 'rspec-rails'
 
+group :test do
+  gem 'super_diff'
+end
+
 group :development do
   gem 'pry'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'super_diff/rspec'
 
 module SpecHelper
   def repo_root


### PR DESCRIPTION
While I was working on smart merge or other new feature proposal, it was a quite annoying to spot the actual diffs on two big hashes (OpenAPI definitions). 
This PR proposes to add https://github.com/mcmire/super_diff, as `:test` dependency,  which improves QoL on development.

## Before 
<img width="1497" alt="image" src="https://user-images.githubusercontent.com/127635/177955100-66d9aafc-46bf-40b5-acfd-ad8c30e2543f.png">

## After
<img width="622" alt="image" src="https://user-images.githubusercontent.com/127635/177954997-c47c6099-7888-4c0b-8a33-623cfeb3605f.png">
