### PR TITLE
Bump Rails v6.0.3.x to fix bundle failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rspec-openapi.gemspec
 gemspec
 
-gem 'rails', ENV['RAILS_VERSION'] || '6.0.3.2'
+gem 'rails', ENV['RAILS_VERSION'] || '6.0.3.7'
 gem 'roda'
 gem 'rspec-rails'
 


### PR DESCRIPTION
Currently `bundle` will fail on the transitive dependency `mimemagic` if no mime-type database is found on a machine.
[Rails v6.0.3.6 dropped mimemagic](https://github.com/rails/rails/releases/tag/v6.0.3.6).
Since we do not use `mimemagic`-related feature, I think it is better to update so future contributor can bundle without headaches.

See https://rubyonrails.org/2021/3/26/marcel-upgrade-releases
> Before 1.0.0, Marcel—which is distributed under the terms of the MIT License, like Rails—indirectly depended on MIME type data released under the incompatible GNU General Public License. Marcel 1.0.0 instead directly packages MIME type data adapted from [Apache Tika](https://tika.apache.org/), released under the permissive and compatible Apache License 2.0.
