### PR TITLE
Setup RuboCop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,37 @@
+name: "Rubocop"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Rubocop run
+      run: |
+        bash -c "
+          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+          [[ $? -ne 2 ]]
+        "
+
+    - name: Upload Sarif output
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: rubocop.sarif

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ end
 
 group :development do
   gem 'pry'
+  gem "code-scanning-rubocop"
 end

--- a/lib/rspec/openapi/hooks.rb
+++ b/lib/rspec/openapi/hooks.rb
@@ -12,7 +12,7 @@ error_records = {}
 
 RSpec.configuration.after(:each) do |example|
   if RSpec::OpenAPI.example_types.include?(example.metadata[:type]) && example.metadata[:openapi] != false
-    path = RSpec::OpenAPI.path.yield_self { |path| path.is_a?(Proc) ? path.call(example) : path }
+    path = RSpec::OpenAPI.path.yield_self { |p| p.is_a?(Proc) ? p.call(example) : p }
     record = RSpec::OpenAPI::RecordBuilder.build(self, example: example)
     path_records[path] << record if record
   end

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -1,5 +1,5 @@
 RSpec::OpenAPI::Record = Struct.new(
-  :method,                # @param [String]  - "GET"
+  :http_method,           # @param [String]  - "GET"
   :path,                  # @param [String]  - "/v1/status/:id"
   :path_params,           # @param [Hash]    - {:controller=>"v1/statuses", :action=>"create", :id=>"1"}
   :query_params,          # @param [Hash]    - {:query=>"string"}

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -49,7 +49,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     end
 
     RSpec::OpenAPI::Record.new(
-      method: request.request_method,
+      http_method: request.method,
       path: path,
       path_params: raw_path_params(request),
       query_params: request.query_parameters,

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -22,7 +22,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
     {
       paths: {
         normalize_path(record.path) => {
-          record.method.downcase => {
+          record.http_method.downcase => {
             summary: record.summary,
             tags: record.tags,
             parameters: build_parameters(record),


### PR DESCRIPTION
To reduce efforts on code format and code review, let's introduce RuboCop.

This PR fixes some warning-level code offenses.
Other minor offenses will be addressed in subsequent PRs.
