### PR TITLE
Makes header & request params optional and handle empty files gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ Some examples' attributes can be overwritten via RSpec metadata options. Example
     description: 'list all posts ordered by pub_date',
     tags: %w[v1 posts],
     required_request_params: %w[limit],
+    optional_request_params: %w[data optional_address], # request body parameters that will NOT be set as required
+    optional_headers: %w[Accept-Languages rowsPerPage], # request header params that can be optional
     security: [{"MyToken" => []}],
   } do
     # ...

--- a/lib/rspec/openapi/extractors/hanami.rb
+++ b/lib/rspec/openapi/extractors/hanami.rb
@@ -61,6 +61,7 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_request_params = metadata[:optional_request_params] || []
     optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
@@ -77,7 +78,7 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
 
     raw_path_params = raw_path_params.slice(*(raw_path_params.keys - RSpec::OpenAPI.ignored_path_params))
 
-    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/hanami.rb
+++ b/lib/rspec/openapi/extractors/hanami.rb
@@ -61,6 +61,7 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
     deprecated = metadata[:deprecated]
@@ -76,7 +77,7 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
 
     raw_path_params = raw_path_params.slice(*(raw_path_params.keys - RSpec::OpenAPI.ignored_path_params))
 
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rack.rb
+++ b/lib/rspec/openapi/extractors/rack.rb
@@ -11,13 +11,14 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
     deprecated = metadata[:deprecated]
     raw_path_params = request.path_parameters
     path = request.path
     summary ||= "#{request.method} #{path}"
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rack.rb
+++ b/lib/rspec/openapi/extractors/rack.rb
@@ -11,6 +11,7 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_request_params = metadata[:optional_request_params] || []
     optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
@@ -18,7 +19,7 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
     raw_path_params = request.path_parameters
     path = request.path
     summary ||= "#{request.method} #{path}"
-    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -21,6 +21,7 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
     deprecated = metadata[:deprecated]
@@ -34,7 +35,7 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
 
     summary ||= "#{request.method} #{path}"
 
-    [path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -21,6 +21,7 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
     tags = metadata[:tags] || RSpec::OpenAPI.tags_builder.call(example)
     operation_id = metadata[:operation_id]
     required_request_params = metadata[:required_request_params] || []
+    optional_request_params = metadata[:optional_request_params] || []
     optional_headers = metadata[:optional_headers] || []
     security = metadata[:security]
     description = metadata[:description] || RSpec::OpenAPI.description_builder.call(example)
@@ -35,7 +36,7 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
 
     summary ||= "#{request.method} #{path}"
 
-    [path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated]
+    [path, summary, tags, operation_id, required_request_params, optional_request_params, optional_headers, raw_path_params, description, security, deprecated]
   end
 
   # @param [RSpec::ExampleGroups::*] context

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -7,6 +7,7 @@ RSpec::OpenAPI::Record = Struct.new(
   :query_params,          # @param [Hash]    - {:query=>"string"}
   :request_params,        # @param [Hash]    - {:request=>"body"}
   :required_request_params, # @param [Array]    - ["param1", "param2"]
+  :optional_request_params, # @param [Array]    - ["param3", "param4"]
   :request_content_type,  # @param [String]  - "application/json"
   :request_headers,       # @param [Array]  - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
   :optional_headers,      # @param [Array] - ["header1", "header2"]

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -9,6 +9,7 @@ RSpec::OpenAPI::Record = Struct.new(
   :required_request_params, # @param [Array]    - ["param1", "param2"]
   :request_content_type,  # @param [String]  - "application/json"
   :request_headers,       # @param [Array]  - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
+  :optional_headers,      # @param [Array] - ["header1", "header2"]
   :summary,               # @param [String]  - "v1/statuses #show"
   :tags,                  # @param [Array]   - ["Status"]
   :operation_id,          # @param [String]   - "request-1234"

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -11,7 +11,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     request, response = extractor.request_response(context)
     return if request.nil?
 
-    path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated =
+    path, summary, tags, operation_id, required_request_params, optional_request_params, optional_headers, raw_path_params, description, security, deprecated =
       extractor.request_attributes(request, example)
 
     return if RSpec::OpenAPI.ignored_paths.any? { |ignored_path| path.match?(ignored_path) }
@@ -25,6 +25,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       query_params: request.query_parameters,
       request_params: raw_request_params(request),
       required_request_params: required_request_params,
+      optional_request_params: optional_request_params,
       optional_headers: optional_headers,
       request_content_type: request.media_type,
       request_headers: request_headers,

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -11,7 +11,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     request, response = extractor.request_response(context)
     return if request.nil?
 
-    path, summary, tags, operation_id, required_request_params, raw_path_params, description, security, deprecated =
+    path, summary, tags, operation_id, required_request_params, optional_headers, raw_path_params, description, security, deprecated =
       extractor.request_attributes(request, example)
 
     return if RSpec::OpenAPI.ignored_paths.any? { |ignored_path| path.match?(ignored_path) }
@@ -25,6 +25,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       query_params: request.query_parameters,
       request_params: raw_request_params(request),
       required_request_params: required_request_params,
+      optional_headers: optional_headers,
       request_content_type: request.media_type,
       request_headers: request_headers,
       summary: summary,

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -88,7 +88,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       {
         name: build_parameter_name(key, value),
         in: 'header',
-        required: true,
+        required: record.optional_headers.exclude?(key),
         schema: build_property(try_cast(value)),
         example: (try_cast(value) if example_enabled?),
       }.compact

--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -24,7 +24,11 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    RSpec::OpenAPI::KeyTransformer.symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
+    content = YAML.safe_load(File.read(@path)) # This can also parse JSON
+
+    return {} if content.nil?
+
+    RSpec::OpenAPI::KeyTransformer.symbolize(content)
   end
 
   # @param [Hash] spec


### PR DESCRIPTION
Hello good people, I hope all is well.

This PR introduces three minor changes to the `rspec-openapi` gem:

1. **Header params can now be optional and by default required:**
  In the previous implementation, all header params were marked as required (`required: true`). Now, header params are optional, and by default required. The logic has been updated to check the `optional_headers` field, and any headers not present in that list are considered required (`record.optional_headers.exclude?(key)`)

2. **Requets body params can now be optional and by default required:**
  In the previous implementation, all request body params were marked as required from the `enrich_with_required_keys` method, (`obj[:required] = obj[:properties]&.keys || []`). Now, request body params are optional, and by default required. The logic has been updated to check the `optional_request_params` field in the record, and any params not present in that list are considered required (`(obj[:properties]&.keys - optional_request_params) || []`)

3. **Gracefully handle empty files during YAML/JSON parsing:**
  The previous implementation would raise errors when attempting to load an empty YAML/JSON file. The update adds a check to ensure that if the content is nil (i.e., the file is empty), an empty hash {} is returned, avoiding any errors. _(Check the provided error at the bottom)._

These changes improve flexibility in defining required headers and prevent errors when dealing with empty files. Please note that I have tested these on a **Rails API**, provided changes should be tested in other frameworks.

P.S. Automated unit test is not provided since the changes doesn't modify the intended behavior of these methods by default current tests should cover these as well.

Raised Error mentioned in 3:
```
Failure/Error: base.replace(RSpec::OpenAPI::KeyTransformer.symbolize(base))

NoMethodError:
  undefined method `replace' for nil
```