### PR TITLE
fix: account for entry always being nullable

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -311,7 +311,9 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
 
         has_nullable = all_prop_variations.any?(&:nil?) || nullable_only.any?
 
-        if prop_variations.size == 1
+        if prop_variations.empty? && has_nullable
+          merged[:properties][key] = { nullable: true }
+        elsif prop_variations.size == 1
           merged[:properties][key] = prop_variations.first.dup
           merged[:properties][key][:nullable] = true if has_nullable
         elsif prop_variations.size > 1

--- a/spec/apps/hanami/app/actions/array_hashes/nested_objects.rb
+++ b/spec/apps/hanami/app/actions/array_hashes/nested_objects.rb
@@ -20,7 +20,8 @@ module HanamiTest
                     "label" => "Duplicate",
                     "modal" => {
                       "confirm_action" => {
-                        "label" => "Duplicate"
+                        "label" => "Duplicate",
+                        "endpoint" => nil
                       }
                     }
                   },
@@ -31,7 +32,8 @@ module HanamiTest
                     "label" => "Something Else Again",
                     "modal" => {
                       "confirm_action" => {
-                        "label" => nil
+                        "label" => nil,
+                        "endpoint" => nil
                       }
                     }
                   }
@@ -49,7 +51,8 @@ module HanamiTest
                     "label" => "Duplicate",
                     "modal" => {
                       "confirm_action" => {
-                        "label" => "Duplicate"
+                        "label" => "Duplicate",
+                        "endpoint" => nil
                       }
                     }
                   },
@@ -60,7 +63,8 @@ module HanamiTest
                     "label" => "Something Else Again",
                     "modal" => {
                       "confirm_action" => {
-                        "label" => nil
+                        "label" => nil,
+                        "endpoint" => nil
                       }
                     }
                   }

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -376,6 +376,9 @@
                                         "label": {
                                           "type": "string",
                                           "nullable": true
+                                        },
+                                        "endpoint": {
+                                          "nullable": true
                                         }
                                       },
                                       "required": [
@@ -419,7 +422,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -430,7 +434,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }
@@ -448,7 +453,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -459,7 +465,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -244,6 +244,8 @@ paths:
                                       label:
                                         type: string
                                         nullable: true
+                                      endpoint:
+                                        nullable: true
                                     required:
                                     - label
                                 required:
@@ -267,11 +269,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 2
                   metadata:
                     author: Bob
@@ -282,11 +286,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 3
                   metadata:
                     author: Charlie

--- a/spec/apps/rails/app/controllers/array_hashes_controller.rb
+++ b/spec/apps/rails/app/controllers/array_hashes_controller.rb
@@ -138,7 +138,8 @@ class ArrayHashesController < ApplicationController
               "label" => "Duplicate",
               "modal" => {
                 "confirm_action" => {
-                  "label" => "Duplicate"
+                  "label" => "Duplicate",
+                  "endpoint" => nil
                 }
               }
             },
@@ -149,7 +150,8 @@ class ArrayHashesController < ApplicationController
               "label" => "Something Else Again",
               "modal" => {
                 "confirm_action" => {
-                  "label" => nil
+                  "label" => nil,
+                  "endpoint" => nil
                 }
               }
             }
@@ -167,7 +169,8 @@ class ArrayHashesController < ApplicationController
               "label" => "Duplicate",
               "modal" => {
                 "confirm_action" => {
-                  "label" => "Duplicate"
+                  "label" => "Duplicate",
+                  "endpoint" => nil
                 }
               }
             },
@@ -178,7 +181,8 @@ class ArrayHashesController < ApplicationController
               "label" => "Something Else Again",
               "modal" => {
                 "confirm_action" => {
-                  "label" => nil
+                  "label" => nil,
+                  "endpoint" => nil
                 }
               }
             }

--- a/spec/apps/rails/doc/minitest_openapi.json
+++ b/spec/apps/rails/doc/minitest_openapi.json
@@ -419,6 +419,9 @@
                                         "label": {
                                           "type": "string",
                                           "nullable": true
+                                        },
+                                        "endpoint": {
+                                          "nullable": true
                                         }
                                       },
                                       "required": [
@@ -462,7 +465,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -473,7 +477,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }
@@ -491,7 +496,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -502,7 +508,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }

--- a/spec/apps/rails/doc/minitest_openapi.yaml
+++ b/spec/apps/rails/doc/minitest_openapi.yaml
@@ -272,6 +272,8 @@ paths:
                                       label:
                                         type: string
                                         nullable: true
+                                      endpoint:
+                                        nullable: true
                                     required:
                                     - label
                                 required:
@@ -295,11 +297,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 2
                   metadata:
                     author: Bob
@@ -310,11 +314,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 3
                   metadata:
                     author: Charlie

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -419,6 +419,9 @@
                                         "label": {
                                           "type": "string",
                                           "nullable": true
+                                        },
+                                        "endpoint": {
+                                          "nullable": true
                                         }
                                       },
                                       "required": [
@@ -462,7 +465,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -473,7 +477,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }
@@ -491,7 +496,8 @@
                           "label": "Duplicate",
                           "modal": {
                             "confirm_action": {
-                              "label": "Duplicate"
+                              "label": "Duplicate",
+                              "endpoint": null
                             }
                           }
                         },
@@ -502,7 +508,8 @@
                           "label": "Something Else Again",
                           "modal": {
                             "confirm_action": {
-                              "label": null
+                              "label": null,
+                              "endpoint": null
                             }
                           }
                         }

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -272,6 +272,8 @@ paths:
                                       label:
                                         type: string
                                         nullable: true
+                                      endpoint:
+                                        nullable: true
                                     required:
                                     - label
                                 required:
@@ -295,11 +297,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 2
                   metadata:
                     author: Bob
@@ -310,11 +314,13 @@ paths:
                     modal:
                       confirm_action:
                         label: Duplicate
+                        endpoint:
                   - label: Edit
                   - label: Something Else Again
                     modal:
                       confirm_action:
                         label:
+                        endpoint:
                 - id: 3
                   metadata:
                     author: Charlie


### PR DESCRIPTION
**Summary**

In most recent fixes to nullability, forgot to account for something _always_ being null. This fixes that (#280)

**Controller body**
```ruby
    {
      "items" => [
        {
          "id" => 1,
          "metadata" => {
            "author" => "Alice",
            "version" => "1.0"
          },
          "actions" => [
            {
              "label" => "Duplicate",
              "modal" => {
                "confirm_action" => {
                  "label" => "Duplicate",
                  "endpoint" => nil
                }
              }
            },
            {
              "label" => "Edit",
            },
            {
              "label" => "Something Else Again",
              "modal" => {
                "confirm_action" => {
                  "label" => nil,
                  "endpoint" => nil
                }
              }
            }
          ]
        },
        {
          "id" => 2,
          "metadata" => {
            "author" => "Bob",
            "version" => "2.0",
            "reviewed" => true
          },
          "actions" => [
            {
              "label" => "Duplicate",
              "modal" => {
                "confirm_action" => {
                  "label" => "Duplicate",
                  "endpoint" => nil
                }
              }
            },
            {
              "label" => "Edit",
            },
            {
              "label" => "Something Else Again",
              "modal" => {
                "confirm_action" => {
                  "label" => nil,
                  "endpoint" => nil
                }
              }
            }
          ]
        },
        {
          "id" => 3,
          "metadata" => {
            "author" => "Charlie"
          }
        }
      ]
    }
```

**Before**
```
...
                                properties:
                                  confirm_action:
                                    type: object
                                    properties:
                                      label:
                                        type: string
                                        nullable: true
                                    required:
                                    - label
```

**After**
```
...
                                properties:
                                  confirm_action:
                                    type: object
                                    properties:
                                      label:
                                        type: string
                                        nullable: true
                                      endpoint:
                                        nullable: true
                                    required:
                                    - label
```