### PR TITLE
fix: handle array hashes where item can be very different types

### DIFF
--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -25,7 +25,12 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
 
     spec.each do |key, value|
       if base[key].is_a?(Hash) && value.is_a?(Hash)
-        merge_schema!(base[key], value) unless base[key].key?(:$ref)
+        # If the new value has oneOf, replace the entire value instead of merging
+        if value.key?(:oneOf)
+          base[key] = value
+        else
+          merge_schema!(base[key], value) unless base[key].key?(:$ref)
+        end
       elsif base[key].is_a?(Array) && value.is_a?(Array)
         # parameters need to be merged as if `name` and `in` were the Hash keys.
         merge_arrays(base, key, value)

--- a/spec/apps/hanami/app/actions/array_hashes/mixed_types_nested.rb
+++ b/spec/apps/hanami/app/actions/array_hashes/mixed_types_nested.rb
@@ -14,7 +14,26 @@ module HanamiTest
                 "config" => {
                   "port" => 8080,
                   "host" => "localhost"
-                }
+                },
+                "form" => [
+                  {
+                    "value" => "John Doe",
+                    "options" => [
+                      {"label" => "John Doe", "value" => "john_doe"},
+                      {"label" => "Jane Doe", "value" => "jane_doe"}
+                    ]
+                  },
+                  {
+                    "value" => [],
+                    "options" => {
+                      "endpoint" => "some/endpoint"
+                    }
+                  },
+                  {
+                    "value" => nil,
+                    "options" => nil
+                  },
+                ]
               },
               {
                 "id" => 2,
@@ -22,7 +41,8 @@ module HanamiTest
                   "port" => "3000",
                   "host" => "example.com",
                   "ssl" => true
-                }
+                },
+                "form" => nil
               }
             ]
           }.to_json

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -94,6 +94,65 @@
                               "port",
                               "host"
                             ]
+                          },
+                          "form": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {}
+                                    }
+                                  ],
+                                  "nullable": true
+                                },
+                                "options": {
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "label",
+                                          "value"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "endpoint": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "endpoint"
+                                      ]
+                                    }
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "options"
+                              ]
+                            },
+                            "nullable": true
                           }
                         },
                         "required": [
@@ -114,7 +173,32 @@
                       "config": {
                         "port": 8080,
                         "host": "localhost"
-                      }
+                      },
+                      "form": [
+                        {
+                          "value": "John Doe",
+                          "options": [
+                            {
+                              "label": "John Doe",
+                              "value": "john_doe"
+                            },
+                            {
+                              "label": "Jane Doe",
+                              "value": "jane_doe"
+                            }
+                          ]
+                        },
+                        {
+                          "value": [],
+                          "options": {
+                            "endpoint": "some/endpoint"
+                          }
+                        },
+                        {
+                          "value": null,
+                          "options": null
+                        }
+                      ]
                     },
                     {
                       "id": 2,
@@ -122,7 +206,8 @@
                         "port": "3000",
                         "host": "example.com",
                         "ssl": true
-                      }
+                      },
+                      "form": null
                     }
                   ]
                 }

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -69,6 +69,41 @@ paths:
                           required:
                           - port
                           - host
+                        form:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              value:
+                                oneOf:
+                                - type: string
+                                - type: array
+                                  items: {}
+                                nullable: true
+                              options:
+                                oneOf:
+                                - type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      label:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - label
+                                    - value
+                                - type: object
+                                  properties:
+                                    endpoint:
+                                      type: string
+                                  required:
+                                  - endpoint
+                                nullable: true
+                            required:
+                            - value
+                            - options
+                          nullable: true
                       required:
                       - id
                       - config
@@ -80,11 +115,24 @@ paths:
                   config:
                     port: 8080
                     host: localhost
+                  form:
+                  - value: John Doe
+                    options:
+                    - label: John Doe
+                      value: john_doe
+                    - label: Jane Doe
+                      value: jane_doe
+                  - value: []
+                    options:
+                      endpoint: some/endpoint
+                  - value:
+                    options:
                 - id: 2
                   config:
                     port: '3000'
                     host: example.com
                     ssl: true
+                  form:
   "/array_hashes/nested":
     get:
       summary: nested

--- a/spec/apps/rails/app/controllers/array_hashes_controller.rb
+++ b/spec/apps/rails/app/controllers/array_hashes_controller.rb
@@ -207,7 +207,26 @@ class ArrayHashesController < ApplicationController
           "config" => {
             "port" => 8080,
             "host" => "localhost"
-          }
+          },
+          "form" => [
+            {
+              "value" => "John Doe",
+              "options" => [
+                {"label" => "John Doe", "value" => "john_doe"},
+                {"label" => "Jane Doe", "value" => "jane_doe"}
+              ]
+            },
+            {
+              "value" => [],
+              "options" => {
+                "endpoint" => "some/endpoint"
+              }
+            },
+            {
+              "value" => nil,
+              "options" => nil
+            },
+          ]
         },
         {
           "id" => 2,
@@ -215,7 +234,8 @@ class ArrayHashesController < ApplicationController
             "port" => "3000",
             "host" => "example.com",
             "ssl" => true
-          }
+          },
+          "form" => nil
         }
       ]
     }

--- a/spec/apps/rails/doc/minitest_openapi.json
+++ b/spec/apps/rails/doc/minitest_openapi.json
@@ -137,6 +137,65 @@
                               "port",
                               "host"
                             ]
+                          },
+                          "form": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {}
+                                    }
+                                  ],
+                                  "nullable": true
+                                },
+                                "options": {
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "label",
+                                          "value"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "endpoint": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "endpoint"
+                                      ]
+                                    }
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "options"
+                              ]
+                            },
+                            "nullable": true
                           }
                         },
                         "required": [
@@ -157,7 +216,32 @@
                       "config": {
                         "port": 8080,
                         "host": "localhost"
-                      }
+                      },
+                      "form": [
+                        {
+                          "value": "John Doe",
+                          "options": [
+                            {
+                              "label": "John Doe",
+                              "value": "john_doe"
+                            },
+                            {
+                              "label": "Jane Doe",
+                              "value": "jane_doe"
+                            }
+                          ]
+                        },
+                        {
+                          "value": [],
+                          "options": {
+                            "endpoint": "some/endpoint"
+                          }
+                        },
+                        {
+                          "value": null,
+                          "options": null
+                        }
+                      ]
                     },
                     {
                       "id": 2,
@@ -165,7 +249,8 @@
                         "port": "3000",
                         "host": "example.com",
                         "ssl": true
-                      }
+                      },
+                      "form": null
                     }
                   ]
                 }

--- a/spec/apps/rails/doc/minitest_openapi.yaml
+++ b/spec/apps/rails/doc/minitest_openapi.yaml
@@ -97,6 +97,41 @@ paths:
                           required:
                           - port
                           - host
+                        form:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              value:
+                                oneOf:
+                                - type: string
+                                - type: array
+                                  items: {}
+                                nullable: true
+                              options:
+                                oneOf:
+                                - type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      label:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - label
+                                    - value
+                                - type: object
+                                  properties:
+                                    endpoint:
+                                      type: string
+                                  required:
+                                  - endpoint
+                                nullable: true
+                            required:
+                            - value
+                            - options
+                          nullable: true
                       required:
                       - id
                       - config
@@ -108,11 +143,24 @@ paths:
                   config:
                     port: 8080
                     host: localhost
+                  form:
+                  - value: John Doe
+                    options:
+                    - label: John Doe
+                      value: john_doe
+                    - label: Jane Doe
+                      value: jane_doe
+                  - value: []
+                    options:
+                      endpoint: some/endpoint
+                  - value:
+                    options:
                 - id: 2
                   config:
                     port: '3000'
                     host: example.com
                     ssl: true
+                  form:
   "/array_hashes/nested":
     get:
       summary: nested

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -137,6 +137,65 @@
                               "port",
                               "host"
                             ]
+                          },
+                          "form": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {}
+                                    }
+                                  ],
+                                  "nullable": true
+                                },
+                                "options": {
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "label",
+                                          "value"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "endpoint": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "endpoint"
+                                      ]
+                                    }
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "options"
+                              ]
+                            },
+                            "nullable": true
                           }
                         },
                         "required": [
@@ -157,7 +216,32 @@
                       "config": {
                         "port": 8080,
                         "host": "localhost"
-                      }
+                      },
+                      "form": [
+                        {
+                          "value": "John Doe",
+                          "options": [
+                            {
+                              "label": "John Doe",
+                              "value": "john_doe"
+                            },
+                            {
+                              "label": "Jane Doe",
+                              "value": "jane_doe"
+                            }
+                          ]
+                        },
+                        {
+                          "value": [],
+                          "options": {
+                            "endpoint": "some/endpoint"
+                          }
+                        },
+                        {
+                          "value": null,
+                          "options": null
+                        }
+                      ]
                     },
                     {
                       "id": 2,
@@ -165,7 +249,8 @@
                         "port": "3000",
                         "host": "example.com",
                         "ssl": true
-                      }
+                      },
+                      "form": null
                     }
                   ]
                 }

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -97,6 +97,41 @@ paths:
                           required:
                           - port
                           - host
+                        form:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              value:
+                                oneOf:
+                                - type: string
+                                - type: array
+                                  items: {}
+                                nullable: true
+                              options:
+                                oneOf:
+                                - type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      label:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - label
+                                    - value
+                                - type: object
+                                  properties:
+                                    endpoint:
+                                      type: string
+                                  required:
+                                  - endpoint
+                                nullable: true
+                            required:
+                            - value
+                            - options
+                          nullable: true
                       required:
                       - id
                       - config
@@ -108,11 +143,24 @@ paths:
                   config:
                     port: 8080
                     host: localhost
+                  form:
+                  - value: John Doe
+                    options:
+                    - label: John Doe
+                      value: john_doe
+                    - label: Jane Doe
+                      value: jane_doe
+                  - value: []
+                    options:
+                      endpoint: some/endpoint
+                  - value:
+                    options:
                 - id: 2
                   config:
                     port: '3000'
                     host: example.com
                     ssl: true
+                  form:
   "/array_hashes/nested":
     get:
       summary: nested


### PR DESCRIPTION
## Summary

Found an issue where an array of hashes where a key can be very different types was not creating a `oneOf` as expected (#288 )

**Example**
```json
{
  "fields": [
    {
      "value": "John Doe"
    },
    {
      "value": []
    }
  ]
}
```

**Before**
```yaml
...
                        form:
                          type: array
                          items:
                            type: object
                            properties:
                              value:
                                - type: string
                            required:
                            - value
                          nullable: true
```

**Now**
```yaml
...
                        form:
                          type: array
                          items:
                            type: object
                            properties:
                              value:
                                oneOf:
                                - type: string
                                - type: array
                                  items: {}
                            required:
                            - value
                          nullable: true
```