### PR TITLE
fix: safely extract request/response when let() overrides exist

### DIFF
--- a/spec/apps/rails/app/controllers/tables_controller.rb
+++ b/spec/apps/rails/app/controllers/tables_controller.rb
@@ -12,6 +12,10 @@ class TablesController < ApplicationController
     end
   end
 
+  def override_probe
+    render json: { ok: true }
+  end
+
   def show
     render json: find_table(params[:id])
   end

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   defaults format: 'json' do
+    get '/override_probe' => 'tables#override_probe'
     resources :sites, param: :name, only: [:show]
     resources :tables, only: [:index, :show, :create, :update, :destroy]
     resources :images, only: [:index, :show] do


### PR DESCRIPTION
## Summary
- Fixes OpenAPI extraction when users define `let(:request)` or `let(:response)` in their specs
- Prioritizes `integration_session` if available for request/response extraction
- Falls back to detecting RSpec memoized helpers and calling `super_method` to get actual objects

## Test plan
- [x] Added integration test that defines `let(:request)` and `let(:response)` overrides
- [x] Test verifies OpenAPI record is still generated with correct status code

Related issue https://github.com/exoego/rspec-openapi/issues/251