### PR TITLE
fix: allow multiple types of parameters

### DIFF
--- a/spec/apps/rails/app/controllers/tables_controller.rb
+++ b/spec/apps/rails/app/controllers/tables_controller.rb
@@ -47,7 +47,7 @@ class TablesController < ApplicationController
   def find_table(id = nil)
     time = Time.parse('2020-07-17 00:00:00')
     case id
-    when '1', nil
+    when 'abc-123', '1', nil
       {
         id: 1,
         name: 'access',

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -2561,9 +2561,16 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
-            "example": 1
+            "example": "abc-123"
           }
         ],
         "requestBody": {
@@ -2588,7 +2595,7 @@
         },
         "responses": {
           "200": {
-            "description": "returns a table",
+            "description": "returns a table via a UUID",
             "content": {
               "application/json": {
                 "schema": {
@@ -2645,18 +2652,39 @@
                     "updated_at"
                   ]
                 },
-                "example": {
-                  "id": 1,
-                  "name": "access",
-                  "description": "logs",
-                  "database": {
-                    "id": 2,
-                    "name": "production"
+                "examples": {
+                  "returns_a_table": {
+                    "summary": "returns a table",
+                    "value": {
+                      "id": 1,
+                      "name": "access",
+                      "description": "logs",
+                      "database": {
+                        "id": 2,
+                        "name": "production"
+                      },
+                      "null_sample": null,
+                      "storage_size": 12.3,
+                      "created_at": "2020-07-17T00:00:00+00:00",
+                      "updated_at": "2020-07-17T00:00:00+00:00"
+                    }
                   },
-                  "null_sample": null,
-                  "storage_size": 12.3,
-                  "created_at": "2020-07-17T00:00:00+00:00",
-                  "updated_at": "2020-07-17T00:00:00+00:00"
+                  "returns_a_table_via_a_uuid": {
+                    "summary": "returns a table via a UUID",
+                    "value": {
+                      "id": 1,
+                      "name": "access",
+                      "description": "logs",
+                      "database": {
+                        "id": 2,
+                        "name": "production"
+                      },
+                      "null_sample": null,
+                      "storage_size": 12.3,
+                      "created_at": "2020-07-17T00:00:00+00:00",
+                      "updated_at": "2020-07-17T00:00:00+00:00"
+                    }
+                  }
                 }
               }
             }

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -1585,8 +1585,10 @@ paths:
         in: path
         required: true
         schema:
-          type: integer
-        example: 1
+          oneOf:
+          - type: integer
+          - type: string
+        example: abc-123
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -1601,7 +1603,7 @@ paths:
               name: test
       responses:
         '200':
-          description: returns a table
+          description: returns a table via a UUID
           content:
             application/json:
               schema:
@@ -1643,17 +1645,33 @@ paths:
                 - storage_size
                 - created_at
                 - updated_at
-              example:
-                id: 1
-                name: access
-                description: logs
-                database:
-                  id: 2
-                  name: production
-                null_sample:
-                storage_size: 12.3
-                created_at: '2020-07-17T00:00:00+00:00'
-                updated_at: '2020-07-17T00:00:00+00:00'
+              examples:
+                returns_a_table:
+                  summary: returns a table
+                  value:
+                    id: 1
+                    name: access
+                    description: logs
+                    database:
+                      id: 2
+                      name: production
+                    null_sample:
+                    storage_size: 12.3
+                    created_at: '2020-07-17T00:00:00+00:00'
+                    updated_at: '2020-07-17T00:00:00+00:00'
+                returns_a_table_via_a_uuid:
+                  summary: returns a table via a UUID
+                  value:
+                    id: 1
+                    name: access
+                    description: logs
+                    database:
+                      id: 2
+                      name: production
+                    null_sample:
+                    storage_size: 12.3
+                    created_at: '2020-07-17T00:00:00+00:00'
+                    updated_at: '2020-07-17T00:00:00+00:00'
   "/tags":
     post:
       summary: POST /tags

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -117,9 +117,14 @@ RSpec.describe 'Tables', type: :request do
     end
   end
 
-  describe '#update' do
+  describe '#update', openapi: { example_mode: :multiple } do
     it 'returns a table' do
       patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns a table via a UUID' do
+      patch '/tables/abc-123', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
       expect(response.status).to eq(200)
     end
   end


### PR DESCRIPTION
Found an issue where a controller that takes one parameter with multiple types does not get picked up correctly. For example, a controller that takes a param `id_or_uuid` which is either an `id` (number) or `uuid` (string), only one will get chosen for OpenAPI.

This fix ensures any params are converted to `oneOf` if there are more than one types.

```ruby
    it 'returns a table' do
      patch '/tables/1', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
      expect(response.status).to eq(200)
    end

    it 'returns a table via a UUID' do
      patch '/tables/abc-123', headers: { authorization: 'k0kubun' }, params: { name: 'test' }
      expect(response.status).to eq(200)
    end
```
```yaml
      parameters:
      - name: id
        in: path
        required: true
        schema:
          oneOf:
          - type: integer
          - type: string
        example: abc-123
```

Fixes #309 