### PR TITLE
fix: guard against nil parent in cleanup_empty_required_array!

### DIFF
--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -70,6 +70,8 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     ]
     paths_to_objects.each do |path|
       parent = base.dig(*path.take(path.length - 1))
+      next unless parent
+
       # "required" array  must not be present if empty
       parent.delete(:required) if parent[:required] && parent[:required].empty?
     end


### PR DESCRIPTION
Closes #325

One of our apps using this threw an error in specs:

```
An error occurred in an `after(:suite)` hook.
Failure/Error: parent.delete(:required) if parent[:required] && parent[:required].empty?

NoMethodError:
  undefined method '[]' for nil
# /root/project/vendor/bundle/ruby/3.4.0/gems/rspec-openapi-0.25.0/lib/rspec/openapi/schema_cleaner.rb:74:in 'block in cleanup_empty_required_array!'
# /root/project/vendor/bundle/ruby/3.4.0/gems/rspec-openapi-0.25.0/lib/rspec/openapi/schema_cleaner.rb:71:in 'Array#each'
# /root/project/vendor/bundle/ruby/3.4.0/gems/rspec-openapi-0.25.0/lib/rspec/openapi/schema_cleaner.rb:71:in 'cleanup_empty_required_array!'
# /root/project/vendor/bundle/ruby/3.4.0/gems/rspec-openapi-0.25.0/lib/rspec/openapi/result_recorder.rb:60:in 'RSpec::OpenAPI::ResultRecorder#cleanup_schema!'
# /root/project/vendor/bundle/ruby/3.4.0/gems/rspec-openapi-0.25.0/lib/rspec/openapi/result_recorder.rb:32:in 'block (2 levels) in RSpec::OpenAPI::ResultRecorder#record_results!'
```

Fixed by ensuring `parent` exists before doing `parent[:required]`