### PR TITLE
feat: support additionalProperties via openapi metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,99 @@ it 'creates a task', openapi: {
 end
 ```
 
+### Dynamic-key Object Support (`additionalProperties`)
+
+When an endpoint returns (or accepts) an object whose keys are not part of its
+schema — for example a permissions map `{ "can_edit": true, "can_delete": false }`
+where new permissions can appear without an API change — rspec-openapi would
+otherwise capture the test response literally and emit each observed key as a
+fixed property. You can override this with the `additional_properties` metadata,
+which replaces the captured `properties` / `required` of the matched object with
+[`additionalProperties`](https://swagger.io/docs/specification/data-models/dictionaries/).
+
+Keys are dot-notation paths (the same scheme as `enum`); the empty string `""`
+targets the body root.
+
+```rb
+it 'returns a permission map', openapi: {
+  additional_properties: { 'data' => { type: 'boolean' } },
+} do
+  get '/api/v1/permissions'
+  # Response: { "data": { "can_edit": true, "can_delete": false } }
+  expect(response.status).to eq(200)
+end
+```
+
+This generates:
+
+```yaml
+schema:
+  type: object
+  properties:
+    data:
+      type: object
+      additionalProperties:
+        type: boolean
+  required:
+    - data
+```
+
+#### Root-level dynamic keys
+
+When the entire body is a dynamic dict, use `''` as the path:
+
+```rb
+it 'lists organisation memberships', openapi: {
+  additional_properties: { '' => { type: 'boolean' } },
+} do
+  get '/api/v1/organisations/acme/check_memberships'
+  # Response: { "user-hash-a": true, "user-hash-b": false }
+  expect(response.status).to eq(200)
+end
+```
+
+```yaml
+schema:
+  type: object
+  additionalProperties:
+    type: boolean
+```
+
+#### Schemas referenced via `$ref`
+
+The value of `additionalProperties` can be any schema, including a `$ref`:
+
+```rb
+it 'returns tags by id', openapi: {
+  additional_properties: { '' => { '$ref' => '#/components/schemas/Tag' } },
+} do
+  get '/tags'
+  expect(response.status).to eq(200)
+end
+```
+
+```yaml
+schema:
+  type: object
+  additionalProperties:
+    $ref: '#/components/schemas/Tag'
+```
+
+#### Request vs Response
+
+`additional_properties` applies to both request and response by default. Use
+`request_additional_properties` / `response_additional_properties` to scope to
+one side:
+
+```rb
+it 'records arbitrary metrics', openapi: {
+  request_additional_properties: { '' => { type: 'integer' } },
+} do
+  post '/metrics', params: { 'page_views' => 100, 'signups' => 5 }
+  expect(response.status).to eq(201)
+end
+```
+
 ### Multiple Examples Mode
 
 You can generate multiple named examples for the same endpoint using `example_mode`:

--- a/lib/rspec/openapi/extractors/hanami.rb
+++ b/lib/rspec/openapi/extractors/hanami.rb
@@ -55,7 +55,8 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
     return RSpec::OpenAPI::Extractors::Rack.request_attributes(request, example) unless route.routable?
 
     summary, tags, formats, operation_id, required_request_params, security, description, deprecated, example_mode,
-      example_key, example_name, response_enum, request_enum = SharedExtractor.attributes(example)
+      example_key, example_name, response_enum, request_enum, response_additional_properties,
+      request_additional_properties = SharedExtractor.attributes(example)
 
     path = request.path
 
@@ -85,6 +86,8 @@ class << RSpec::OpenAPI::Extractors::Hanami = Object.new
       example_name,
       response_enum,
       request_enum,
+      response_additional_properties,
+      request_additional_properties,
     ]
   end
 

--- a/lib/rspec/openapi/extractors/rack.rb
+++ b/lib/rspec/openapi/extractors/rack.rb
@@ -7,7 +7,8 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
   # @return Array
   def request_attributes(request, example)
     summary, tags, formats, operation_id, required_request_params, security, description, deprecated, example_mode,
-      example_key, example_name, response_enum, request_enum = SharedExtractor.attributes(example)
+      example_key, example_name, response_enum, request_enum, response_additional_properties,
+      request_additional_properties = SharedExtractor.attributes(example)
 
     raw_path_params = request.path_parameters
     path = request.path
@@ -29,6 +30,8 @@ class << RSpec::OpenAPI::Extractors::Rack = Object.new
       example_name,
       response_enum,
       request_enum,
+      response_additional_properties,
+      request_additional_properties,
     ]
   end
 

--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -17,7 +17,8 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
     raise "No route matched for #{fixed_request.request_method} #{fixed_request.path_info}" if route.nil?
 
     summary, tags, formats, operation_id, required_request_params, security, description, deprecated, example_mode,
-      example_key, example_name, response_enum, request_enum = SharedExtractor.attributes(example)
+      example_key, example_name, response_enum, request_enum, response_additional_properties,
+      request_additional_properties = SharedExtractor.attributes(example)
 
     raw_path_params = request.path_parameters
 
@@ -45,6 +46,8 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
       example_name,
       response_enum,
       request_enum,
+      response_additional_properties,
+      request_additional_properties,
     ]
   end
 

--- a/lib/rspec/openapi/extractors/shared_extractor.rb
+++ b/lib/rspec/openapi/extractors/shared_extractor.rb
@@ -50,18 +50,7 @@ class SharedExtractor
     return nil if hash.nil? || hash.empty?
 
     hash.each_with_object({}) do |(path, schema), result|
-      result[path.to_s] = symbolize_schema(schema)
-    end
-  end
-
-  def self.symbolize_schema(value)
-    case value
-    when Hash
-      value.each_with_object({}) { |(k, v), h| h[k.to_sym] = symbolize_schema(v) }
-    when Array
-      value.map { |v| symbolize_schema(v) }
-    else
-      value
+      result[path.to_s] = RSpec::OpenAPI::KeyTransformer.symbolize(schema)
     end
   end
 

--- a/lib/rspec/openapi/extractors/shared_extractor.rb
+++ b/lib/rspec/openapi/extractors/shared_extractor.rb
@@ -32,8 +32,6 @@ class SharedExtractor
      request_additional_properties,]
   end
 
-  # additionalProperties support: response/request-specific overrides fall back to
-  # the general `additional_properties` metadata when not provided.
   def self.resolve_additional_properties(metadata)
     base = normalize_additional_properties(metadata[:additional_properties])
     response = normalize_additional_properties(metadata[:response_additional_properties]) || base
@@ -48,13 +46,6 @@ class SharedExtractor
     enum_hash.transform_keys(&:to_s)
   end
 
-  # Normalize additional_properties metadata.
-  # Outer keys identify object paths in the schema using dot notation
-  # (matching the path scheme used by `enum`).
-  # Values are user-supplied schemas describing the value type for the
-  # dynamic keys: e.g. { type: 'boolean' }, { '$ref' => '#/components/schemas/Foo' },
-  # or even fully-formed nested schemas. Inner hash keys are symbolized so the
-  # value is consumable by SchemaBuilder without further transformation.
   def self.normalize_additional_properties(hash)
     return nil if hash.nil? || hash.empty?
 

--- a/lib/rspec/openapi/extractors/shared_extractor.rb
+++ b/lib/rspec/openapi/extractors/shared_extractor.rb
@@ -25,8 +25,20 @@ class SharedExtractor
     response_enum = normalize_enum(metadata[:response_enum]) || base_enum
     request_enum = normalize_enum(metadata[:request_enum]) || base_enum
 
+    response_additional_properties, request_additional_properties = resolve_additional_properties(metadata)
+
     [summary, tags, formats, operation_id, required_request_params, security, description, deprecated, example_mode,
-     example_key, example_name, response_enum, request_enum,]
+     example_key, example_name, response_enum, request_enum, response_additional_properties,
+     request_additional_properties,]
+  end
+
+  # additionalProperties support: response/request-specific overrides fall back to
+  # the general `additional_properties` metadata when not provided.
+  def self.resolve_additional_properties(metadata)
+    base = normalize_additional_properties(metadata[:additional_properties])
+    response = normalize_additional_properties(metadata[:response_additional_properties]) || base
+    request = normalize_additional_properties(metadata[:request_additional_properties]) || base
+    [response, request]
   end
 
   def self.normalize_enum(enum_hash)
@@ -34,6 +46,32 @@ class SharedExtractor
 
     # Convert all keys to strings for consistent lookup
     enum_hash.transform_keys(&:to_s)
+  end
+
+  # Normalize additional_properties metadata.
+  # Outer keys identify object paths in the schema using dot notation
+  # (matching the path scheme used by `enum`).
+  # Values are user-supplied schemas describing the value type for the
+  # dynamic keys: e.g. { type: 'boolean' }, { '$ref' => '#/components/schemas/Foo' },
+  # or even fully-formed nested schemas. Inner hash keys are symbolized so the
+  # value is consumable by SchemaBuilder without further transformation.
+  def self.normalize_additional_properties(hash)
+    return nil if hash.nil? || hash.empty?
+
+    hash.each_with_object({}) do |(path, schema), result|
+      result[path.to_s] = symbolize_schema(schema)
+    end
+  end
+
+  def self.symbolize_schema(value)
+    case value
+    when Hash
+      value.each_with_object({}) { |(k, v), h| h[k.to_sym] = symbolize_schema(v) }
+    when Array
+      value.map { |v| symbolize_schema(v) }
+    else
+      value
+    end
   end
 
   def self.merge_openapi_metadata(metadata)

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -28,10 +28,7 @@ RSpec::OpenAPI::Record = Struct.new(
   :response_content_disposition, # @param [String]  - "inline"
   :response_enum,         # @param [Hash]    - {"status" => ["active", "inactive"], "user.role" => ["admin", "user"]}
   :request_enum,          # @param [Hash]    - {"type" => ["create", "update"]}
-  # Hash of dot-notation path => value-schema for `additionalProperties`.
-  # Empty-string path targets the body root.
-  # Example: { "data" => { type: "boolean" }, "" => { "$ref": "#/components/schemas/Tag" } }
-  :response_additional_properties,
-  :request_additional_properties,
+  :response_additional_properties, # @param [Hash] - {"data" => { type: "boolean" }}
+  :request_additional_properties,  # @param [Hash] - {"meta" => { type: "string" }}
   keyword_init: true,
 )

--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -28,5 +28,10 @@ RSpec::OpenAPI::Record = Struct.new(
   :response_content_disposition, # @param [String]  - "inline"
   :response_enum,         # @param [Hash]    - {"status" => ["active", "inactive"], "user.role" => ["admin", "user"]}
   :request_enum,          # @param [Hash]    - {"type" => ["create", "update"]}
+  # Hash of dot-notation path => value-schema for `additionalProperties`.
+  # Empty-string path targets the body root.
+  # Example: { "data" => { type: "boolean" }, "" => { "$ref": "#/components/schemas/Tag" } }
+  :response_additional_properties,
+  :request_additional_properties,
   keyword_init: true,
 )

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -14,7 +14,8 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
     title = RSpec::OpenAPI.title.then { |t| t.is_a?(Proc) ? t.call(example) : t }
     path, summary, tags, operation_id, required_request_params, raw_path_params,
       description, security, deprecated, formats, example_mode, example_key,
-      example_name, response_enum, request_enum = extractor.request_attributes(request, example)
+      example_name, response_enum, request_enum, response_additional_properties,
+      request_additional_properties = extractor.request_attributes(request, example)
 
     return if RSpec::OpenAPI.ignored_paths.any? { |ignored_path| path.match?(ignored_path) }
 
@@ -48,6 +49,8 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       example_name: example_name,
       response_enum: response_enum,
       request_enum: request_enum,
+      response_additional_properties: response_additional_properties,
+      request_additional_properties: request_additional_properties,
     ).freeze
   end
 

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -289,6 +289,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
                 end
     return nil unless overrides
 
+    # path is nil at the body root; nil.to_s == '' lets users target it via { '' => ... }
     overrides[path.to_s]
   end
 

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -289,9 +289,6 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
                 end
     return nil unless overrides
 
-    # Keys are already normalized to strings by SharedExtractor.normalize_additional_properties.
-    # `path` is nil at the root of a body schema; nil.to_s == '' — so users can target the
-    # entire body with `additional_properties: { '' => ... }`.
     overrides[path.to_s]
   end
 

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -217,13 +217,18 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
                            build_array_items_schema(value, record: record, path: path, context: context)
                          end
     when Hash
-      property[:properties] = {}.tap do |properties|
-        value.each do |k, v|
-          child_path = path ? "#{path}.#{k}" : k.to_s
-          properties[k] = build_property(v, record: record, key: k, path: child_path, context: context)
+      additional_properties_schema = infer_additional_properties(path, record, context)
+      if additional_properties_schema
+        property[:additionalProperties] = additional_properties_schema
+      else
+        property[:properties] = {}.tap do |properties|
+          value.each do |k, v|
+            child_path = path ? "#{path}.#{k}" : k.to_s
+            properties[k] = build_property(v, record: record, key: k, path: child_path, context: context)
+          end
         end
+        property = enrich_with_required_keys(property)
       end
-      property = enrich_with_required_keys(property)
     end
     property
   end
@@ -272,6 +277,22 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
 
     # Keys are already normalized to strings by SharedExtractor.normalize_enum
     enum_hash[path.to_s]
+  end
+
+  def infer_additional_properties(path, record, context)
+    return nil unless record
+
+    overrides = if context == :request
+                  record.request_additional_properties
+                else
+                  record.response_additional_properties
+                end
+    return nil unless overrides
+
+    # Keys are already normalized to strings by SharedExtractor.normalize_additional_properties.
+    # `path` is nil at the root of a body schema; nil.to_s == '' — so users can target the
+    # entire body with `additional_properties: { '' => ... }`.
+    overrides[path.to_s]
   end
 
   # Convert an always-String param to an appropriate type

--- a/spec/apps/rails/app/controllers/dynamic_keys_test_controller.rb
+++ b/spec/apps/rails/app/controllers/dynamic_keys_test_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DynamicKeysTestController < ApplicationController
+  # Wrapped under a `data` field – the issue's original example.
+  def wrapped
+    render json: {
+      data: {
+        can_do_thing: true,
+        can_do_other_thing: false,
+        can_do_third_thing: true,
+      },
+    }
+  end
+
+  # Root-level dynamic dict – the PE-1357 `check_memberships` shape.
+  def root
+    render json: {
+      'org-one' => true,
+      'org-two' => false,
+      'org-three' => true,
+    }
+  end
+
+  # Dynamic dict whose values follow a complex shape (intended for $ref override).
+  def complex_values
+    render json: {
+      'tag-1' => { id: 1, label: 'urgent' },
+      'tag-2' => { id: 2, label: 'normal' },
+    }
+  end
+
+  # Request body has dynamic keys; response is plain.
+  def create
+    render json: { ok: true }, status: 201
+  end
+end

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -76,6 +76,12 @@ Rails.application.routes.draw do
     post '/enum_test' => 'enum_test#create'
     get '/enum_test/deeply_nested' => 'enum_test#deeply_nested'
 
+    # Dynamic-key (additionalProperties) test routes
+    get '/dynamic_keys_test/wrapped' => 'dynamic_keys_test#wrapped'
+    get '/dynamic_keys_test/root' => 'dynamic_keys_test#root'
+    get '/dynamic_keys_test/complex_values' => 'dynamic_keys_test#complex_values'
+    post '/dynamic_keys_test' => 'dynamic_keys_test#create'
+
     # Test route for invalid example_mode error handling
     get '/invalid_example_mode' => ->(_env) { [200, { 'Content-Type' => 'application/json' }, ['{"status":"ok"}']] }
   end

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -1066,6 +1066,152 @@
         }
       }
     },
+    "/dynamic_keys_test": {
+      "post": {
+        "summary": "create",
+        "tags": [
+          "DynamicKeysTest"
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                }
+              },
+              "example": {
+                "metric_a": "1",
+                "metric_b": "2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "applies additionalProperties only to the request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dynamic_keys_test/complex_values": {
+      "get": {
+        "summary": "complex_values",
+        "tags": [
+          "DynamicKeysTest"
+        ],
+        "responses": {
+          "200": {
+            "description": "supports $ref schemas as the additionalProperties value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/Tag"
+                  }
+                },
+                "example": {
+                  "tag-1": {
+                    "id": 1,
+                    "label": "urgent"
+                  },
+                  "tag-2": {
+                    "id": 2,
+                    "label": "normal"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dynamic_keys_test/root": {
+      "get": {
+        "summary": "root",
+        "tags": [
+          "DynamicKeysTest"
+        ],
+        "responses": {
+          "200": {
+            "description": "applies additionalProperties at the body root using empty string path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                },
+                "example": {
+                  "org-one": true,
+                  "org-two": false,
+                  "org-three": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dynamic_keys_test/wrapped": {
+      "get": {
+        "summary": "wrapped",
+        "tags": [
+          "DynamicKeysTest"
+        ],
+        "responses": {
+          "200": {
+            "description": "replaces the data field properties with additionalProperties",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "can_do_thing": true,
+                    "can_do_other_thing": false,
+                    "can_do_third_thing": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/empty_example_name": {
       "get": {
         "summary": "GET /empty_example_name",

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -1078,7 +1078,11 @@
               "schema": {
                 "type": "object",
                 "additionalProperties": {
-                  "type": "integer"
+                  "type": "string",
+                  "enum": [
+                    "1",
+                    "2"
+                  ]
                 }
               },
               "example": {
@@ -1090,7 +1094,7 @@
         },
         "responses": {
           "201": {
-            "description": "applies additionalProperties only to the request body",
+            "description": "applies additionalProperties only to the request body and supports array values in the schema",
             "content": {
               "application/json": {
                 "schema": {

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -635,13 +635,17 @@ paths:
             schema:
               type: object
               additionalProperties:
-                type: integer
+                type: string
+                enum:
+                - '1'
+                - '2'
             example:
               metric_a: '1'
               metric_b: '2'
       responses:
         '201':
-          description: applies additionalProperties only to the request body
+          description: applies additionalProperties only to the request body and supports
+            array values in the schema
           content:
             application/json:
               schema:

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -624,6 +624,99 @@ paths:
                   summary: My Custom Name
                   value:
                     data: custom_name
+  "/dynamic_keys_test":
+    post:
+      summary: create
+      tags:
+      - DynamicKeysTest
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties:
+                type: integer
+            example:
+              metric_a: '1'
+              metric_b: '2'
+      responses:
+        '201':
+          description: applies additionalProperties only to the request body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                - ok
+              example:
+                ok: true
+  "/dynamic_keys_test/complex_values":
+    get:
+      summary: complex_values
+      tags:
+      - DynamicKeysTest
+      responses:
+        '200':
+          description: supports $ref schemas as the additionalProperties value
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  "$ref": "#/components/schemas/Tag"
+              example:
+                tag-1:
+                  id: 1
+                  label: urgent
+                tag-2:
+                  id: 2
+                  label: normal
+  "/dynamic_keys_test/root":
+    get:
+      summary: root
+      tags:
+      - DynamicKeysTest
+      responses:
+        '200':
+          description: applies additionalProperties at the body root using empty string
+            path
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: boolean
+              example:
+                org-one: true
+                org-two: false
+                org-three: true
+  "/dynamic_keys_test/wrapped":
+    get:
+      summary: wrapped
+      tags:
+      - DynamicKeysTest
+      responses:
+        '200':
+          description: replaces the data field properties with additionalProperties
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties:
+                      type: boolean
+                required:
+                - data
+              example:
+                data:
+                  can_do_thing: true
+                  can_do_other_thing: false
+                  can_do_third_thing: true
   "/empty_example_name":
     get:
       summary: GET /empty_example_name

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -669,9 +669,9 @@ RSpec.describe 'Dynamic key (additionalProperties) support', type: :request do
     end
   end
 
-  describe 'request-side override' do
-    it 'applies additionalProperties only to the request body', openapi: {
-      request_additional_properties: { '' => { type: 'integer' } },
+  describe 'request-side override with enum array value' do
+    it 'applies additionalProperties only to the request body and supports array values in the schema', openapi: {
+      request_additional_properties: { '' => { type: 'string', enum: %w[1 2] } },
     } do
       post '/dynamic_keys_test', params: { 'metric_a' => 1, 'metric_b' => 2 }
       expect(response.status).to eq(201)

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -639,3 +639,42 @@ RSpec.describe 'Enum support', type: :request do
     end
   end
 end
+
+# additionalProperties (dynamic-key object) support tests
+RSpec.describe 'Dynamic key (additionalProperties) support', type: :request do
+  describe 'wrapped under a field' do
+    it 'replaces the data field properties with additionalProperties', openapi: {
+      additional_properties: { 'data' => { type: 'boolean' } },
+    } do
+      get '/dynamic_keys_test/wrapped'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'root-level dynamic keys' do
+    it 'applies additionalProperties at the body root using empty string path', openapi: {
+      additional_properties: { '' => { type: 'boolean' } },
+    } do
+      get '/dynamic_keys_test/root'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'with $ref value' do
+    it 'supports $ref schemas as the additionalProperties value', openapi: {
+      additional_properties: { '' => { '$ref' => '#/components/schemas/Tag' } },
+    } do
+      get '/dynamic_keys_test/complex_values'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'request-side override' do
+    it 'applies additionalProperties only to the request body', openapi: {
+      request_additional_properties: { '' => { type: 'integer' } },
+    } do
+      post '/dynamic_keys_test', params: { 'metric_a' => 1, 'metric_b' => 2 }
+      expect(response.status).to eq(201)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #328.

Adds an `additional_properties` RSpec metadata option (and `request_additional_properties` / `response_additional_properties` variants) so endpoints that return — or accept — objects with dynamic keys produce `additionalProperties` in the generated schema instead of capturing each observed key as a fixed property.

```ruby
it 'returns a permissions map', openapi: {
  additional_properties: { 'data' => { type: 'boolean' } },
} do
  get '/api/v1/permissions'
  # Response: { "data": { "can_edit": true, "can_delete": false } }
  expect(response.status).to eq(200)
end
```

```yaml
schema:
  type: object
  properties:
    data:
      type: object
      additionalProperties:
        type: boolean
  required:
    - data
```

## Design

Plumbed through exactly the same pipeline as the existing `enum` feature:

`SharedExtractor.attributes` → all 3 framework extractors (rails / rack / hanami) → `Record` → `SchemaBuilder#infer_additional_properties`.

In `build_property`, when the value is a `Hash` and the current dot-path matches an override, the override schema replaces what would otherwise be the captured `properties` / `required`. Schema *values* are passed through verbatim so both primitive types and `$ref` schemas are supported, as you suggested in the issue.

### Path matching

Keys are dot-notation paths (the same scheme used by `enum`). One small extension: an empty-string path `''` targets the body root, which covers the common "the whole response body is a dynamic dict" case — e.g. a memberships/permissions lookup that returns ``{"<id>" => boolean}`` directly with no wrapper. `nil.to_s == ""` makes that fall out naturally at the root of the schema-builder's recursion.

### Supported value shapes

- Primitive: `{ type: 'boolean' }`, `{ type: 'integer' }`, …
- `$ref`: `{ '$ref' => '#/components/schemas/Tag' }`
- Any other valid OpenAPI schema fragment (passed through with keys symbolized to match the rest of the builder).

### Request vs response

Following the `enum` precedent: `additional_properties` applies to both sides; `request_additional_properties` / `response_additional_properties` scope to one. The request-side override targets the request body schema, request params, etc. — wherever `build_property` recurses.

## What's covered

- Top-level field replaced with `additionalProperties` (the issue's example shape).
- Root-level dynamic dict via `''` path.
- `$ref` schema as the value.
- Request-body-only override.

All four scenarios are exercised by new request specs in `spec/requests/rails_spec.rb` against a new `DynamicKeysTestController`, and the corresponding YAML/JSON fixtures are committed so the integration test (`spec/rspec/rails_spec.rb`) verifies the full round-trip.

The schema merger already handled `additionalProperties` correctly (it preserves it across regenerations and skips `properties` / `required` where it's present), so no merger changes were needed.
