### PR TITLE
feat: make parameters optional if not appeared in all test cases

### DIFF
--- a/lib/rspec/openapi/schema_merger.rb
+++ b/lib/rspec/openapi/schema_merger.rb
@@ -72,21 +72,33 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
   end
 
   def merge_parameters(base, key, value)
-    all_parameters = value | base[key]
+    base_params = index_parameters_by_identity(base[key])
+    new_params = index_parameters_by_identity(value)
 
-    unique_base_parameters = build_unique_params(base, key)
+    base[key] = (base_params.keys | new_params.keys).map do |param_key|
+      base_param = base_params[param_key]
+      new_param = new_params[param_key]
 
-    all_parameters = all_parameters.map do |parameter|
-      base_parameter = unique_base_parameters[[parameter[:name], parameter[:in]]] || {}
-      if base_parameter.empty?
-        parameter
+      if base_param && new_param
+        merge_parameter_with_schema(base_param, new_param)
+      elsif new_param
+        # Parameter only in the new spec. Treat as optional unless its `required: true`
+        # came from explicit `required_request_params` metadata — distinguishable only
+        # for `query`, where the schema_builder default is `required: false`. `header`
+        # defaults to `required: true`, so the value alone can't signal user intent.
+        new_param[:in] == 'query' && new_param[:required] ? new_param : mark_optional_unless_path(new_param)
       else
-        merge_parameter_with_schema(base_parameter, parameter)
+        mark_optional_unless_path(base_param)
       end
     end
+  end
 
-    all_parameters.uniq! { |param| param.slice(:name, :in) }
-    base[key] = all_parameters
+  # OpenAPI requires `in: path` parameters to be `required: true`, so this leaves
+  # them untouched.
+  def mark_optional_unless_path(parameter)
+    return parameter if parameter[:in] == 'path'
+
+    parameter.merge(required: false)
   end
 
   def merge_parameter_with_schema(base_param, new_param)
@@ -94,12 +106,20 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
     new_schema = new_param[:schema]
 
     # If schemas have different types, create a oneOf
-    if base_schema && new_schema && schemas_have_different_types?(base_schema, new_schema)
-      merged_schema = merge_schemas_into_one_of(base_schema, new_schema)
-      base_param.merge(new_param).merge(schema: merged_schema)
-    else
-      base_param.merge(new_param)
+    merged = if base_schema && new_schema && schemas_have_different_types?(base_schema, new_schema)
+               merged_schema = merge_schemas_into_one_of(base_schema, new_schema)
+               base_param.merge(new_param).merge(schema: merged_schema)
+             else
+               base_param.merge(new_param)
+             end
+
+    # Once a parameter has been seen missing in any earlier test case, keep it optional
+    # even if later test cases mark it required again.
+    if base_param[:required] == false || new_param[:required] == false
+      merged = mark_optional_unless_path(merged)
     end
+
+    merged
   end
 
   def schemas_have_different_types?(schema1, schema2)
@@ -133,10 +153,8 @@ class << RSpec::OpenAPI::SchemaMerger = Object.new
     end
   end
 
-  def build_unique_params(base, key)
-    base[key].to_h do |parameter|
-      [[parameter[:name], parameter[:in]], parameter]
-    end
+  def index_parameters_by_identity(parameters)
+    parameters.to_h { |p| [[p[:name], p[:in]], p] }
   end
 
   # Normalize example/examples fields when there's a conflict

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -2016,7 +2016,7 @@
           {
             "name": "X-Authorization-Token",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -1219,7 +1219,7 @@ paths:
       parameters:
       - name: X-Authorization-Token
         in: header
-        required: true
+        required: false
         schema:
           type: string
         example: token

--- a/spec/apps/rails/doc/minitest_openapi.json
+++ b/spec/apps/rails/doc/minitest_openapi.json
@@ -1478,7 +1478,7 @@
           {
             "name": "X-Authorization-Token",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },

--- a/spec/apps/rails/doc/minitest_openapi.yaml
+++ b/spec/apps/rails/doc/minitest_openapi.yaml
@@ -879,7 +879,7 @@ paths:
       parameters:
       - name: X-Authorization-Token
         in: header
-        required: true
+        required: false
         schema:
           type: string
         example: token

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -3032,7 +3032,7 @@
           {
             "name": "X-Authorization-Token",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             },

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -1868,7 +1868,7 @@ paths:
       parameters:
       - name: X-Authorization-Token
         in: header
-        required: true
+        required: false
         schema:
           type: string
         example: token

--- a/spec/rspec/scheme_merger_spec.rb
+++ b/spec/rspec/scheme_merger_spec.rb
@@ -157,4 +157,160 @@ RSpec.describe 'schema merger spec' do
       )
     end
   end
+
+  describe 'parameter optionality across test cases' do
+    it 'keeps required: true when the same parameter appears in both specs' do
+      base = {
+        parameters: [
+          { name: 'X-Auth', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'X-Auth', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to eq([
+                                          { name: 'X-Auth', in: 'header', required: true, schema: { type: 'string' } },
+                                        ])
+    end
+
+    it 'demotes a header that is missing from the new spec to required: false' do
+      base = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+          { name: 'X-Bar', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+        { name: 'X-Bar', in: 'header', required: false, schema: { type: 'string' } },
+      )
+    end
+
+    it 'demotes a newly appearing header to required: false' do
+      # Newly appearing parameters are also treated as optional — they were
+      # missing in earlier test cases. Headers have no metadata to express
+      # "explicit required" intent, so the default-`required: true` is overridden.
+      base = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+          { name: 'X-Bar', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+        { name: 'X-Bar', in: 'header', required: false, schema: { type: 'string' } },
+      )
+    end
+
+    it 'preserves a newly appearing query param when explicitly marked via required_request_params' do
+      # The schema_builder only sets `required: true` on query params listed in
+      # `required_request_params`, so a value-only query with `required: true`
+      # signals explicit user intent and is respected.
+      base = {
+        parameters: [
+          { name: 'page', in: 'query', required: false, schema: { type: 'integer' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'page', in: 'query', required: false, schema: { type: 'integer' } },
+          { name: 'limit', in: 'query', required: true, schema: { type: 'integer' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'page', in: 'query', required: false, schema: { type: 'integer' } },
+        { name: 'limit', in: 'query', required: true, schema: { type: 'integer' } },
+      )
+    end
+
+    it 'keeps optional once a parameter has been observed missing (optional propagation)' do
+      # Simulates 3 test cases where X-Bar appears in cases 1 and 3 but is missing in case 2.
+      # After case 2 demotes X-Bar to optional, case 3's `required: true` should NOT undo it.
+      base = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+          { name: 'X-Bar', in: 'header', required: false, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+          { name: 'X-Bar', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'X-Foo', in: 'header', required: true, schema: { type: 'string' } },
+        { name: 'X-Bar', in: 'header', required: false, schema: { type: 'string' } },
+      )
+    end
+
+    it 'demotes query parameters the same way' do
+      base = {
+        parameters: [
+          { name: 'page', in: 'query', required: true, schema: { type: 'integer' } },
+          { name: 'filter', in: 'query', required: true, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'page', in: 'query', required: true, schema: { type: 'integer' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'page', in: 'query', required: true, schema: { type: 'integer' } },
+        { name: 'filter', in: 'query', required: false, schema: { type: 'string' } },
+      )
+    end
+
+    it 'keeps path parameters required even if missing from one spec' do
+      base = {
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+          { name: 'X-Auth', in: 'header', required: true, schema: { type: 'string' } },
+        ],
+      }
+      spec = {
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+        ],
+      }
+
+      result = RSpec::OpenAPI::SchemaMerger.merge!(base, spec)
+
+      expect(result[:parameters]).to contain_exactly(
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+        { name: 'X-Auth', in: 'header', required: false, schema: { type: 'string' } },
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

An alternative to #236.
Auto-detect optional request parameters by comparing across test cases at merge time.
No new metadata required.

## Motivation

- Headers are always emitted as `required: true`, even when they're only sent in a subset of the test cases for an endpoint

## Changes
- `SchemaMerger#merge_parameters` now compares parameters across merges:
    - In both base and new spec → merge normally
    - In base only → demote to `required: false`
    - In new spec only → demote to `required: false`, unless it's a query param with `required: true`
- Optional propagation: once a parameter is seen missing in any merge, later occurrences won't promote it back to `required: true`
- `path` parameters are always exempt — per the [OpenAPI 3.0.3 spec](https://spec.openapis.org/oas/v3.0.3#parameter-object), they must stay `required: true`
    > If the [parameter location](https://spec.openapis.org/oas/v3.0.3#fixed-fields-9) is "path", this property is REQUIRED and its value MUST be true.　


## Related

- #236 same goal via explicit metadata; this PR takes the auto-detection route instead, as same as in request body and so on