### PR TITLE
feat: handle empty YAML/JSON files gracefully

### DIFF
--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -27,12 +27,10 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    RSpec::OpenAPI::KeyTransformer.symbolize(
-      YAML.safe_load(
-        File.read(@path),
-        permitted_classes: [Date, Time],
-      ),
-    ) # this can also parse JSON
+    content = YAML.safe_load(File.read(@path), permitted_classes: [Date, Time]) # this can also parse JSON
+    return {} if content.nil?
+
+    RSpec::OpenAPI::KeyTransformer.symbolize(content)
   end
 
   # @param [Hash] spec

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe RSpec::OpenAPI::SchemaFile do
+  describe '#edit' do
+    let(:tempfile) { Tempfile.new(['schema', extname]) }
+    let(:path) { tempfile.path }
+
+    after { tempfile.close! }
+
+    {
+      '.yaml' => YAML.method(:safe_load),
+      '.json' => JSON.method(:parse),
+    }.each do |ext, parser|
+      context "with an empty #{ext} file" do
+        let(:extname) { ext }
+
+        it 'treats the contents as an empty hash instead of crashing' do
+          tempfile.close
+
+          captured = nil
+          described_class.new(path).edit do |spec|
+            captured = spec.dup
+            spec[:openapi] = '3.0.0'
+          end
+
+          expect(captured).to eq({})
+          expect(parser.call(File.read(path))).to eq('openapi' => '3.0.0')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Treat an empty YAML/JSON file as an empty hash, instead of crashing with `NoMethodError: undefined method '[]=' for nil`.

## Motivation

`YAML.safe_load("")` returns `nil`, which flow through `KeyTransformer.symbolize` raising the error described above.

This bothers users who creates the empty spec file ahead of the first generation run.

## Related

- #236  proposed this as item 3. This PR addresses that item in isolation.