### PR TITLE
fix: merge heterogeneous nested-array items across outer array items

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -377,10 +377,8 @@ class << RSpec::OpenAPI::SchemaBuilder
     merged =
       if prop_variations.size == 1
         prop_variations.first.dup
-      elsif allow_recursive_merge
-        merge_multi_recursive(prop_variations)
       else
-        merge_multi_array_items(prop_variations)
+        merge_multi(prop_variations)
       end
 
     return merged unless merged.is_a?(Hash)
@@ -397,13 +395,16 @@ class << RSpec::OpenAPI::SchemaBuilder
     merged
   end
 
-  # Array-items mode: combine multiple variations of the same property without
-  # recursing into nested objects/arrays beyond one level.
-  def merge_multi_array_items(prop_variations)
-    unique_types = prop_variations.map { |p| p[:type] }.compact.uniq
-    return one_of_schema(prop_variations) if unique_types.size > 1
+  # Combine multiple variations of the same property: flatten existing oneOf
+  # entries, recurse into objects and arrays, and combine divergent types into
+  # oneOf. Scalar variations of a single type collapse to the first schema.
+  def merge_multi(prop_variations)
+    return { oneOf: flatten_one_of(prop_variations) } if prop_variations.any? { |p| p.key?(:oneOf) }
 
-    case unique_types.first
+    prop_types = prop_variations.map { |p| p[:type] }.compact.uniq
+    return one_of_schema(prop_variations) if prop_types.size > 1
+
+    case prop_types.first
     when 'array'
       items_variations = prop_variations.map { |p| p[:items] }.compact
       { type: 'array', items: build_merged_schema_from_variations(items_variations) }
@@ -412,17 +413,6 @@ class << RSpec::OpenAPI::SchemaBuilder
     else
       prop_variations.first.dup
     end
-  end
-
-  # Recursive-merge mode (used inside build_merged_schema_from_variations):
-  # additionally flattens existing oneOf entries and recurses into objects.
-  def merge_multi_recursive(prop_variations)
-    return { oneOf: flatten_one_of(prop_variations) } if prop_variations.any? { |p| p.key?(:oneOf) }
-
-    prop_types = prop_variations.map { |p| p[:type] }.compact.uniq
-    return one_of_schema(prop_variations) if prop_types.size > 1
-
-    prop_types.first == 'object' ? build_merged_schema_from_variations(prop_variations) : prop_variations.first.dup
   end
 
   def flatten_one_of(prop_variations)

--- a/spec/apps/hanami/app/actions/array_hashes/nested_arrays_across_items.rb
+++ b/spec/apps/hanami/app/actions/array_hashes/nested_arrays_across_items.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module HanamiTest
+  module Actions
+    module ArrayHashes
+      class NestedArraysAcrossItems < HanamiTest::Action
+        def handle(request, response)
+          response.format = :json
+
+          response.body = {
+            "form" => [
+              {
+                "label" => "User details",
+                "inputs" => [
+                  {
+                    "type" => "columns",
+                    "columns" => [
+                      {
+                        "input" => {
+                          "name" => "first_name",
+                          "type" => "text",
+                          "validations" => {
+                            "presence" => true
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type" => "text",
+                    "name" => "email",
+                    "validations" => {
+                      "presence" => true
+                    }
+                  }
+                ]
+              },
+              {
+                "label" => "Billing details",
+                "inputs" => [
+                  {
+                    "type" => "columns",
+                    "columns" => [
+                      {
+                        "input" => {
+                          "name" => "country_code",
+                          "type" => "dropdown",
+                          "validations" => nil,
+                          "answer_options" => [
+                            {"label" => "United Kingdom", "value" => "GB"}
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/apps/hanami/config/routes.rb
+++ b/spec/apps/hanami/config/routes.rb
@@ -34,6 +34,7 @@ module HanamiTest
     get '/array_hashes/nested_objects', to: 'array_hashes.nested_objects'
     get '/array_hashes/mixed_types_nested', to: 'array_hashes.mixed_types_nested'
     get '/array_hashes/multiple_one_of_test', to: 'array_hashes.multiple_one_of_test'
+    get '/array_hashes/nested_arrays_across_items', to: 'array_hashes.nested_arrays_across_items'
 
     get '/test_block', to: ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['A TEST']] }
 

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -598,6 +598,188 @@
         }
       }
     },
+    "/array_hashes/nested_arrays_across_items": {
+      "get": {
+        "summary": "nested_arrays_across_items",
+        "tags": [
+          "ArrayHash"
+        ],
+        "responses": {
+          "200": {
+            "description": "returns nested array shapes that differ between outer array items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "form": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "inputs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "columns": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "input": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "validations": {
+                                            "type": "object",
+                                            "properties": {
+                                              "presence": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "presence"
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "answer_options": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "label": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "label",
+                                                "value"
+                                              ]
+                                            },
+                                            "nullable": true
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "type",
+                                          "validations"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "input"
+                                    ]
+                                  },
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "validations": {
+                                  "type": "object",
+                                  "properties": {
+                                    "presence": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "presence"
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "inputs"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "form"
+                  ]
+                },
+                "example": {
+                  "form": [
+                    {
+                      "label": "User details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "first_name",
+                                "type": "text",
+                                "validations": {
+                                  "presence": true
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "name": "email",
+                          "validations": {
+                            "presence": true
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Billing details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "country_code",
+                                "type": "dropdown",
+                                "validations": null,
+                                "answer_options": [
+                                  {
+                                    "label": "United Kingdom",
+                                    "value": "GB"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/array_hashes/nested_objects": {
       "get": {
         "summary": "nested_objects",

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -331,6 +331,118 @@ paths:
                 - id: 3
                   tags:
                   - javascript
+  "/array_hashes/nested_arrays_across_items":
+    get:
+      summary: nested_arrays_across_items
+      tags:
+      - ArrayHash
+      responses:
+        '200':
+          description: returns nested array shapes that differ between outer array
+            items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  form:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                        inputs:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              columns:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    input:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        type:
+                                          type: string
+                                        validations:
+                                          type: object
+                                          properties:
+                                            presence:
+                                              type: boolean
+                                          required:
+                                          - presence
+                                          nullable: true
+                                        answer_options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              label:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - label
+                                            - value
+                                          nullable: true
+                                      required:
+                                      - name
+                                      - type
+                                      - validations
+                                  required:
+                                  - input
+                                nullable: true
+                              name:
+                                type: string
+                                nullable: true
+                              validations:
+                                type: object
+                                properties:
+                                  presence:
+                                    type: boolean
+                                required:
+                                - presence
+                                nullable: true
+                            required:
+                            - type
+                      required:
+                      - label
+                      - inputs
+                required:
+                - form
+              example:
+                form:
+                - label: User details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: first_name
+                        type: text
+                        validations:
+                          presence: true
+                  - type: text
+                    name: email
+                    validations:
+                      presence: true
+                - label: Billing details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: country_code
+                        type: dropdown
+                        validations:
+                        answer_options:
+                        - label: United Kingdom
+                          value: GB
   "/array_hashes/nested_objects":
     get:
       summary: nested_objects

--- a/spec/apps/rails/app/controllers/array_hashes_controller.rb
+++ b/spec/apps/rails/app/controllers/array_hashes_controller.rb
@@ -250,6 +250,60 @@ class ArrayHashesController < ApplicationController
     render json: response
   end
 
+  def nested_arrays_across_items
+    response = {
+      "form" => [
+        {
+          "label" => "User details",
+          "inputs" => [
+            {
+              "type" => "columns",
+              "columns" => [
+                {
+                  "input" => {
+                    "name" => "first_name",
+                    "type" => "text",
+                    "validations" => {
+                      "presence" => true
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type" => "text",
+              "name" => "email",
+              "validations" => {
+                "presence" => true
+              }
+            }
+          ]
+        },
+        {
+          "label" => "Billing details",
+          "inputs" => [
+            {
+              "type" => "columns",
+              "columns" => [
+                {
+                  "input" => {
+                    "name" => "country_code",
+                    "type" => "dropdown",
+                    "validations" => nil,
+                    "answer_options" => [
+                      {"label" => "United Kingdom", "value" => "GB"}
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    render json: response
+  end
+
   def multiple_one_of_test
     response = {
       "data" => {

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
       get :nested_objects, on: :collection
       get :mixed_types_nested, on: :collection
       get :multiple_one_of_test, on: :collection
+      get :nested_arrays_across_items, on: :collection
     end
 
     scope :admin do

--- a/spec/apps/rails/doc/minitest_openapi.json
+++ b/spec/apps/rails/doc/minitest_openapi.json
@@ -615,6 +615,188 @@
         }
       }
     },
+    "/array_hashes/nested_arrays_across_items": {
+      "get": {
+        "summary": "nested_arrays_across_items",
+        "tags": [
+          "ArrayHash"
+        ],
+        "responses": {
+          "200": {
+            "description": "with heterogeneous nested-array items spread across outer items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "form": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "inputs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "columns": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "input": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "validations": {
+                                            "type": "object",
+                                            "properties": {
+                                              "presence": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "presence"
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "answer_options": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "label": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "label",
+                                                "value"
+                                              ]
+                                            },
+                                            "nullable": true
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "type",
+                                          "validations"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "input"
+                                    ]
+                                  },
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "validations": {
+                                  "type": "object",
+                                  "properties": {
+                                    "presence": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "presence"
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "inputs"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "form"
+                  ]
+                },
+                "example": {
+                  "form": [
+                    {
+                      "label": "User details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "first_name",
+                                "type": "text",
+                                "validations": {
+                                  "presence": true
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "name": "email",
+                          "validations": {
+                            "presence": true
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Billing details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "country_code",
+                                "type": "dropdown",
+                                "validations": null,
+                                "answer_options": [
+                                  {
+                                    "label": "United Kingdom",
+                                    "value": "GB"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/array_hashes/nested_objects": {
       "get": {
         "summary": "nested_objects",

--- a/spec/apps/rails/doc/minitest_openapi.yaml
+++ b/spec/apps/rails/doc/minitest_openapi.yaml
@@ -348,6 +348,117 @@ paths:
                 - id: 3
                   tags:
                   - javascript
+  "/array_hashes/nested_arrays_across_items":
+    get:
+      summary: nested_arrays_across_items
+      tags:
+      - ArrayHash
+      responses:
+        '200':
+          description: with heterogeneous nested-array items spread across outer items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  form:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                        inputs:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              columns:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    input:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        type:
+                                          type: string
+                                        validations:
+                                          type: object
+                                          properties:
+                                            presence:
+                                              type: boolean
+                                          required:
+                                          - presence
+                                          nullable: true
+                                        answer_options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              label:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - label
+                                            - value
+                                          nullable: true
+                                      required:
+                                      - name
+                                      - type
+                                      - validations
+                                  required:
+                                  - input
+                                nullable: true
+                              name:
+                                type: string
+                                nullable: true
+                              validations:
+                                type: object
+                                properties:
+                                  presence:
+                                    type: boolean
+                                required:
+                                - presence
+                                nullable: true
+                            required:
+                            - type
+                      required:
+                      - label
+                      - inputs
+                required:
+                - form
+              example:
+                form:
+                - label: User details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: first_name
+                        type: text
+                        validations:
+                          presence: true
+                  - type: text
+                    name: email
+                    validations:
+                      presence: true
+                - label: Billing details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: country_code
+                        type: dropdown
+                        validations:
+                        answer_options:
+                        - label: United Kingdom
+                          value: GB
   "/array_hashes/nested_objects":
     get:
       summary: nested_objects

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -615,6 +615,188 @@
         }
       }
     },
+    "/array_hashes/nested_arrays_across_items": {
+      "get": {
+        "summary": "nested_arrays_across_items",
+        "tags": [
+          "ArrayHash"
+        ],
+        "responses": {
+          "200": {
+            "description": "returns nested array shapes that differ between outer array items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "form": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "inputs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "columns": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "input": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "validations": {
+                                            "type": "object",
+                                            "properties": {
+                                              "presence": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "presence"
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "answer_options": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "label": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "label",
+                                                "value"
+                                              ]
+                                            },
+                                            "nullable": true
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "type",
+                                          "validations"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "input"
+                                    ]
+                                  },
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "validations": {
+                                  "type": "object",
+                                  "properties": {
+                                    "presence": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "presence"
+                                  ],
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "inputs"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "form"
+                  ]
+                },
+                "example": {
+                  "form": [
+                    {
+                      "label": "User details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "first_name",
+                                "type": "text",
+                                "validations": {
+                                  "presence": true
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "name": "email",
+                          "validations": {
+                            "presence": true
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Billing details",
+                      "inputs": [
+                        {
+                          "type": "columns",
+                          "columns": [
+                            {
+                              "input": {
+                                "name": "country_code",
+                                "type": "dropdown",
+                                "validations": null,
+                                "answer_options": [
+                                  {
+                                    "label": "United Kingdom",
+                                    "value": "GB"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/array_hashes/nested_objects": {
       "get": {
         "summary": "nested_objects",

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -348,6 +348,118 @@ paths:
                 - id: 3
                   tags:
                   - javascript
+  "/array_hashes/nested_arrays_across_items":
+    get:
+      summary: nested_arrays_across_items
+      tags:
+      - ArrayHash
+      responses:
+        '200':
+          description: returns nested array shapes that differ between outer array
+            items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  form:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                        inputs:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              columns:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    input:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        type:
+                                          type: string
+                                        validations:
+                                          type: object
+                                          properties:
+                                            presence:
+                                              type: boolean
+                                          required:
+                                          - presence
+                                          nullable: true
+                                        answer_options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              label:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - label
+                                            - value
+                                          nullable: true
+                                      required:
+                                      - name
+                                      - type
+                                      - validations
+                                  required:
+                                  - input
+                                nullable: true
+                              name:
+                                type: string
+                                nullable: true
+                              validations:
+                                type: object
+                                properties:
+                                  presence:
+                                    type: boolean
+                                required:
+                                - presence
+                                nullable: true
+                            required:
+                            - type
+                      required:
+                      - label
+                      - inputs
+                required:
+                - form
+              example:
+                form:
+                - label: User details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: first_name
+                        type: text
+                        validations:
+                          presence: true
+                  - type: text
+                    name: email
+                    validations:
+                      presence: true
+                - label: Billing details
+                  inputs:
+                  - type: columns
+                    columns:
+                    - input:
+                        name: country_code
+                        type: dropdown
+                        validations:
+                        answer_options:
+                        - label: United Kingdom
+                          value: GB
   "/array_hashes/nested_objects":
     get:
       summary: nested_objects

--- a/spec/integration_tests/rails_test.rb
+++ b/spec/integration_tests/rails_test.rb
@@ -371,6 +371,11 @@ module RailsIntegrationTests
       get '/array_hashes/multiple_one_of_test'
       assert_response 200
     end
+
+    test 'with heterogeneous nested-array items spread across outer items' do
+      get '/array_hashes/nested_arrays_across_items'
+      assert_response 200
+    end
   end
 
   class RSpecHooksAfterSuiteTest < Minitest::Test

--- a/spec/requests/hanami_spec.rb
+++ b/spec/requests/hanami_spec.rb
@@ -587,4 +587,11 @@ RSpec.describe 'Array of hashes', type: :request do
       expect(last_response.status).to eq(200)
     end
   end
+
+  describe 'with heterogeneous nested-array items spread across outer items' do
+    it 'returns nested array shapes that differ between outer array items' do
+      get '/array_hashes/nested_arrays_across_items'
+      expect(last_response.status).to eq(200)
+    end
+  end
 end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -399,6 +399,13 @@ RSpec.describe 'Array of hashes', type: :request do
       expect(response.status).to eq(200)
     end
   end
+
+  describe 'with heterogeneous nested-array items spread across outer items' do
+    it 'returns nested array shapes that differ between outer array items' do
+      get '/array_hashes/nested_arrays_across_items'
+      expect(response.status).to eq(200)
+    end
+  end
 end
 
 # Tests for example_mode feature


### PR DESCRIPTION
Fixes #351

## Problem

Heterogeneous array item shapes merge correctly at the level of the array being merged (#267), but when an array-typed property sits *inside* the items being merged and its shape differs **across the outer items**, the nested array is not merged — the schema sticks on the first-encountered shape, and the recorded response example fails to validate against its own schema.

Minimal trigger: `form[0].inputs[].columns[].input` is a text input, `form[1].inputs[].columns[].input` is a dropdown with extra properties. The merged `columns.items.properties.input` schema only contains the text shape. The same shapes merge fine when they appear within a single `columns` array — the bug only triggers when the variation is spread across different outer items.

## Cause

`merge_multi_array_items` (non-recursive mode) has an explicit `'array'` branch that merges item variations, but its twin `merge_multi_recursive` (used inside `build_merged_schema_from_variations`) does not — array-typed properties fall through to `prop_variations.first.dup`, silently dropping later variations. The two methods had drifted.

## Fix

Unify the two paths into a single `merge_multi` that flattens existing `oneOf` entries, recurses into objects **and arrays**, and turns divergent types into `oneOf`. After adding the missing `'array'` branch the two methods were identical except for the `oneOf`-flattening guard, so keeping them separate only invited further drift. The guard is a no-op for the non-recursive path (schemas built by `build_property` never contain `oneOf`), which the regenerated fixtures confirm.

## Testing

- New fixture endpoint `/array_hashes/nested_arrays_across_items` (rails rspec + minitest + hanami) reproducing the cross-item nested shape; golden yaml/json regenerated.
- All doc regeneration diffs are purely additive — no existing fixture output changed.
- Full suite + rubocop pass.