### PR TITLE
fix: recurse arrays and skip empty items in build_merged_schema_from_variations

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -327,16 +327,30 @@ class << RSpec::OpenAPI::SchemaBuilder
 
   def build_merged_schema_from_variations(variations)
     return {} if variations.empty?
-    return variations.first if variations.size == 1
 
-    types = variations.map { |v| v[:type] }.compact.uniq
-    return variations.first unless types.size == 1 && types.first == 'object'
+    # Drop empty `{}` schemas (e.g. items of an empty array) — they carry no
+    # type info and would otherwise spuriously mark every property of their
+    # populated siblings as nullable via the missing-key nullable rule.
+    non_empty = variations.reject(&:empty?)
+    return {} if non_empty.empty?
+    return non_empty.first if non_empty.size == 1
 
-    {
-      type: 'object',
-      properties: merge_property_variations(variations, allow_recursive_merge: true),
-      required: variations.map { |v| v[:required] || [] }.reduce(:&) || [],
-    }
+    types = non_empty.map { |v| v[:type] }.compact.uniq
+    return one_of_schema(non_empty) if types.size > 1
+
+    case types.first
+    when 'object'
+      {
+        type: 'object',
+        properties: merge_property_variations(non_empty, allow_recursive_merge: true),
+        required: non_empty.map { |v| v[:required] || [] }.reduce(:&) || [],
+      }
+    when 'array'
+      items_variations = non_empty.map { |v| v[:items] }.compact
+      { type: 'array', items: build_merged_schema_from_variations(items_variations) }
+    else
+      non_empty.first
+    end
   end
 
   # Merge the per-key property schemas of multiple object variations.

--- a/spec/apps/rails/app/controllers/array_hashes_controller.rb
+++ b/spec/apps/rails/app/controllers/array_hashes_controller.rb
@@ -304,6 +304,34 @@ class ArrayHashesController < ApplicationController
     render json: response
   end
 
+  # Regression probe (#2): arrays-of-arrays with divergent inner element types.
+  # Outer items each contain `values` whose items are themselves arrays of
+  # differently-typed scalars. Expect the merged items schema to express both
+  # types (oneOf integer/string). If it shows only the first type, the bug is real.
+  def regression_arrays_of_arrays_divergent
+    response = {
+      "items" => [
+        { "values" => [[1, 2, 3]] },
+        { "values" => [["x", "y", "z"]] },
+      ],
+    }
+    render json: response
+  end
+
+  # Regression probe (#3): nested array empty in one outer item, populated in another,
+  # at depth >= 2 of merge recursion. Old merge_multi_recursive would .first.dup arrays
+  # (losing the populated schema); new merge_multi recurses into items and forces every
+  # property nullable. Expect a sensible merge (populated schema preserved, required kept).
+  def regression_nested_array_empty_then_populated
+    response = {
+      "items" => [
+        { "wrapper" => { "tags" => [] } },
+        { "wrapper" => { "tags" => [{ "name" => "first", "value" => 1 }] } },
+      ],
+    }
+    render json: response
+  end
+
   def multiple_one_of_test
     response = {
       "data" => {

--- a/spec/apps/rails/config/routes.rb
+++ b/spec/apps/rails/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
       get :mixed_types_nested, on: :collection
       get :multiple_one_of_test, on: :collection
       get :nested_arrays_across_items, on: :collection
+      get :regression_arrays_of_arrays_divergent, on: :collection
+      get :regression_nested_array_empty_then_populated, on: :collection
     end
 
     scope :admin do

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -1129,6 +1129,161 @@
         }
       }
     },
+    "/array_hashes/regression_arrays_of_arrays_divergent": {
+      "get": {
+        "summary": "regression_arrays_of_arrays_divergent",
+        "tags": [
+          "ArrayHash"
+        ],
+        "responses": {
+          "200": {
+            "description": "should produce items schema expressing both inner types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "values"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                },
+                "example": {
+                  "items": [
+                    {
+                      "values": [
+                        [
+                          1,
+                          2,
+                          3
+                        ]
+                      ]
+                    },
+                    {
+                      "values": [
+                        [
+                          "x",
+                          "y",
+                          "z"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/array_hashes/regression_nested_array_empty_then_populated": {
+      "get": {
+        "summary": "regression_nested_array_empty_then_populated",
+        "tags": [
+          "ArrayHash"
+        ],
+        "responses": {
+          "200": {
+            "description": "should preserve populated schema with sensible required keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "wrapper": {
+                            "type": "object",
+                            "properties": {
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "tags"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "wrapper"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ]
+                },
+                "example": {
+                  "items": [
+                    {
+                      "wrapper": {
+                        "tags": []
+                      }
+                    },
+                    {
+                      "wrapper": {
+                        "tags": [
+                          {
+                            "name": "first",
+                            "value": 1
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/array_hashes/single_item": {
       "get": {
         "summary": "single_item",

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -663,6 +663,93 @@ paths:
                 - label:
                   value: invited
                   invited: true
+  "/array_hashes/regression_arrays_of_arrays_divergent":
+    get:
+      summary: regression_arrays_of_arrays_divergent
+      tags:
+      - ArrayHash
+      responses:
+        '200':
+          description: should produce items schema expressing both inner types
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        values:
+                          type: array
+                          items:
+                            type: array
+                            items:
+                              oneOf:
+                              - type: integer
+                              - type: string
+                      required:
+                      - values
+                required:
+                - items
+              example:
+                items:
+                - values:
+                  - - 1
+                    - 2
+                    - 3
+                - values:
+                  - - x
+                    - "y"
+                    - z
+  "/array_hashes/regression_nested_array_empty_then_populated":
+    get:
+      summary: regression_nested_array_empty_then_populated
+      tags:
+      - ArrayHash
+      responses:
+        '200':
+          description: should preserve populated schema with sensible required keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        wrapper:
+                          type: object
+                          properties:
+                            tags:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: integer
+                                required:
+                                - name
+                                - value
+                          required:
+                          - tags
+                      required:
+                      - wrapper
+                required:
+                - items
+              example:
+                items:
+                - wrapper:
+                    tags: []
+                - wrapper:
+                    tags:
+                    - name: first
+                      value: 1
   "/array_hashes/single_item":
     get:
       summary: single_item

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -406,6 +406,20 @@ RSpec.describe 'Array of hashes', type: :request do
       expect(response.status).to eq(200)
     end
   end
+
+  describe '[regression #2] arrays-of-arrays with divergent inner element types' do
+    it 'should produce items schema expressing both inner types' do
+      get '/array_hashes/regression_arrays_of_arrays_divergent'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe '[regression #3] nested array: empty in one outer item, populated in another at depth >= 2' do
+    it 'should preserve populated schema with sensible required keys' do
+      get '/array_hashes/regression_nested_array_empty_then_populated'
+      expect(response.status).to eq(200)
+    end
+  end
 end
 
 # Tests for example_mode feature


### PR DESCRIPTION
Two follow-up fixes uncovered while reviewing #350

1. For uniform `array` variations, recurse into items instead of returning `variations.first`. Divergent inner element types now collapse to `oneOf` rather than silently dropping the alternates (arrays-of-arrays case).
2. Filter out empty `{}` schemas (e.g. items of an empty inner array) before merging. They carry no type information and otherwise feed `nil` entries into the recursive object merge, forcing every property of the populated sibling to be marked `nullable: true` with `required: []`.

Also emit `oneOf` for divergent top-level types instead of falling through to `variations.first`. Adds two regression endpoints + specs that reproduce the two scenarios.