### PR TITLE
fix: preserve inherited openapi summary/operation_id in nested contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,16 @@ RSpec::OpenAPI.description_builder = -> (example) { example.description }
 
 # Generate a custom summary, given an RSpec example
 # This example uses the summary from the example_group.
+# NOTE: a fixed `dig` only reaches one specific depth. `summary` declared on an
+# ancestor group is already inherited automatically (see "Inheritance of
+# `openapi:` metadata"), so a builder is only needed for fully custom logic.
 RSpec::OpenAPI.summary_builder = ->(example) { example.metadata.dig(:example_group, :openapi, :summary) }
 
 # Generate a custom tags, given an RSpec example
-# This example uses the tags from the parent_example_group
+# This example uses the tags from the parent_example_group.
+# NOTE: `dig(:example_group, :parent_example_group, ...)` only matches tags
+# declared exactly two levels up; it won't find tags on deeper ancestors. Rely
+# on the built-in inheritance unless you need custom resolution.
 RSpec::OpenAPI.tags_builder = -> (example) { example.metadata.dig(:example_group, :parent_example_group, :openapi, :tags) }
 
 # Configure custom format for specific properties
@@ -368,6 +374,26 @@ end
 ```
 
 **NOTE**: `description` key will override also the one provided by `RSpec::OpenAPI.description_builder` method.
+
+### Inheritance of `openapi:` metadata
+
+`openapi:` metadata is inherited from the surrounding `describe`/`context` groups down to each
+example, at any nesting depth. Inner levels override outer ones key by key, so a nested group only
+needs to declare the keys it wants to change:
+
+```rb
+describe 'GET /tables', openapi: { summary: 'Get a list of tables', tags: %w[Table] } do
+  context 'with pagination', openapi: { example_mode: :multiple } do
+    # This example inherits summary: 'Get a list of tables' and tags: ['Table']
+    # from the outer describe, and adds example_mode: :multiple.
+    it { get '/tables', params: { page: 1 } }
+  end
+end
+```
+
+The merge happens at the top level of the `openapi:` hash. Scalar keys (`summary`, `operation_id`,
+…) follow last-wins, and a nested level that re-declares a structured key (`tags`, `security`,
+`enum`, …) replaces the inherited value for that key rather than deep-merging it.
 
 ### Enum Support
 

--- a/lib/rspec/openapi/extractors/shared_extractor.rb
+++ b/lib/rspec/openapi/extractors/shared_extractor.rb
@@ -86,14 +86,12 @@ class SharedExtractor
 
   def self.collect_openapi_metadata(metadata)
     [].tap do |result|
-      current = metadata
+      result.unshift(metadata[:openapi]) if metadata[:openapi]
 
-      while current
-        [current[:example_group], current].each do |meta|
-          result.unshift(meta[:openapi]) if meta&.dig(:openapi)
-        end
-
-        current = current[:parent_example_group]
+      group = metadata.fetch(:example_group) { metadata[:parent_example_group] }
+      while group
+        result.unshift(group[:openapi]) if group[:openapi]
+        group = group[:parent_example_group]
       end
     end
   end

--- a/spec/apps/hanami/doc/openapi.json
+++ b/spec/apps/hanami/doc/openapi.json
@@ -2190,7 +2190,7 @@
     },
     "/tables": {
       "get": {
-        "summary": "index",
+        "summary": "Get a list of tables",
         "tags": [
           "Table"
         ],

--- a/spec/apps/hanami/doc/openapi.yaml
+++ b/spec/apps/hanami/doc/openapi.yaml
@@ -1325,7 +1325,7 @@ paths:
                 message: not found
   "/tables":
     get:
-      summary: index
+      summary: Get a list of tables
       tags:
       - Table
       parameters:

--- a/spec/rspec/shared_extractor_spec.rb
+++ b/spec/rspec/shared_extractor_spec.rb
@@ -75,15 +75,6 @@ RSpec.describe 'SharedExtractor.merge_openapi_metadata' do
         expect(merged[:operation_id]).to eq('listThings')
         expect(merged[:description]).to eq('an edge case')
       end
-
-      # Group metadata has no :example_group, so the walk must fall back to
-      # :parent_example_group (mirroring RSpec::Core::Metadata.ascending).
-      it 'also works when handed group metadata directly' do
-        group_metadata = RSpec.current_example.metadata[:example_group]
-        merged = SharedExtractor.merge_openapi_metadata(group_metadata)
-        expect(merged[:summary]).to eq('List things')
-        expect(merged[:description]).to eq('an edge case')
-      end
     end
   end
 
@@ -119,6 +110,42 @@ RSpec.describe 'SharedExtractor.merge_openapi_metadata' do
           expect(merged[:tags]).to eq(['Things']) # one parent hop up
           expect(merged[:description]).to eq('edge') # immediate
         end
+      end
+    end
+  end
+
+  # Group metadata lacks :example_group, exercising the :parent_example_group
+  # fallback. Synthetic hash avoids the deprecated :example_group alias.
+  describe 'group metadata input (no :example_group key)' do
+    it 'falls back to :parent_example_group and recovers every ancestor level' do
+      root_group = { openapi: { summary: 'List things', operation_id: 'listThings' } }
+      inner_group = { openapi: { description: 'an edge case' }, parent_example_group: root_group }
+      merged = SharedExtractor.merge_openapi_metadata(inner_group)
+      expect(merged).to eq(summary: 'List things', operation_id: 'listThings', description: 'an edge case')
+    end
+  end
+
+  describe 'a nearer level re-declaring keys an ancestor also set',
+           openapi: { summary: 'outer summary', tags: ['Outer'], operation_id: 'outer_op' } do
+    context 'inner', openapi: { tags: ['Inner'], operation_id: 'inner_op' } do
+      it 'replaces structured keys wholesale, last-wins for scalars, recovers ancestor-only keys' do
+        merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+        expect(merged[:tags]).to eq(['Inner'])          # replaced wholesale, not ['Outer', 'Inner']
+        expect(merged[:operation_id]).to eq('inner_op') # nearest scalar wins
+        expect(merged[:summary]).to eq('outer summary') # ancestor-only key recovered
+      end
+    end
+  end
+
+  describe 'example-level override across a multi-level ancestry',
+           openapi: { summary: 'from grandparent', tags: ['Things'] } do
+    context 'middle', openapi: { operation_id: 'from_parent' } do
+      it 'lets the example win over every ancestor yet recovers ancestor-only keys',
+         openapi: { summary: 'from example' } do
+        merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+        expect(merged[:summary]).to eq('from example')     # example beats grandparent
+        expect(merged[:operation_id]).to eq('from_parent') # recovered from middle group
+        expect(merged[:tags]).to eq(['Things'])            # recovered from grandparent
       end
     end
   end

--- a/spec/rspec/shared_extractor_spec.rb
+++ b/spec/rspec/shared_extractor_spec.rb
@@ -65,3 +65,67 @@ RSpec.describe 'SharedExtractor.normalize_example_mode' do
     expect { SharedExtractor.normalize_example_mode(123) }.to raise_error(ArgumentError, /example_mode/)
   end
 end
+
+RSpec.describe 'SharedExtractor.merge_openapi_metadata' do
+  describe 'nested context that overrides :openapi', openapi: { summary: 'List things', operation_id: 'listThings' } do
+    context 'inner', openapi: { description: 'an edge case' } do
+      it "recovers the ancestor's summary and operation_id" do
+        merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+        expect(merged[:summary]).to eq('List things')
+        expect(merged[:operation_id]).to eq('listThings')
+        expect(merged[:description]).to eq('an edge case')
+      end
+
+      # Group metadata has no :example_group, so the walk must fall back to
+      # :parent_example_group (mirroring RSpec::Core::Metadata.ascending).
+      it 'also works when handed group metadata directly' do
+        group_metadata = RSpec.current_example.metadata[:example_group]
+        merged = SharedExtractor.merge_openapi_metadata(group_metadata)
+        expect(merged[:summary]).to eq('List things')
+        expect(merged[:description]).to eq('an edge case')
+      end
+    end
+  end
+
+  describe 'key declared at multiple levels', openapi: { summary: 'outer', tags: ['Things'] } do
+    context 'inner', openapi: { summary: 'inner' } do
+      it 'lets the nearest level win while recovering ancestor-only keys' do
+        merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+        expect(merged[:summary]).to eq('inner')
+        expect(merged[:tags]).to eq(['Things'])
+      end
+    end
+  end
+
+  describe 'example-level override', openapi: { summary: 'from group' } do
+    it "lets the example's own :openapi win over its group", openapi: { summary: 'from example' } do
+      merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+      expect(merged[:summary]).to eq('from example')
+    end
+  end
+
+  describe 'no nested override', openapi: { summary: 'S' } do
+    it 'is a no-op' do
+      expect(SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)).to eq(summary: 'S')
+    end
+  end
+
+  describe 'overrides several levels deep', openapi: { summary: 'List things' } do
+    context 'middle', openapi: { tags: ['Things'] } do
+      context 'inner', openapi: { description: 'edge' } do
+        it 'recovers keys from every ancestor level, not just the immediate parent' do
+          merged = SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)
+          expect(merged[:summary]).to eq('List things') # two parent hops up
+          expect(merged[:tags]).to eq(['Things']) # one parent hop up
+          expect(merged[:description]).to eq('edge') # immediate
+        end
+      end
+    end
+  end
+
+  describe 'no :openapi metadata anywhere' do
+    it 'returns an empty hash' do
+      expect(SharedExtractor.merge_openapi_metadata(RSpec.current_example.metadata)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
Fixes #355

### Problem

When a nested `context`/`describe` declares its own `openapi:` metadata, RSpec *replaces* (does not deep-merge) the inherited `openapi` hash for examples inside it. `SharedExtractor.collect_openapi_metadata` is meant to walk the example-group ancestry and re-merge ancestor levels, but it advanced via `current[:parent_example_group]` starting from the **example** metadata — which has no `:parent_example_group` key (only *group* metadata does). The loop therefore ran once and never visited any ancestor group, so an outer `summary`/`operation_id` was dropped.

For `summary` this is user-visible: the dropped value falls back to the Rails action name (`route.requirements[:action]`), and because records for the same operation are merged last-wins, that action-name summary can overwrite the real summary declared on an outer `describe`.

### Fix

Walk the group ancestry the same way `RSpec::Core::Metadata.ascending` does: start from the example's own `:openapi`, then `fetch(:example_group) { metadata[:parent_example_group] }` and follow `:parent_example_group` upward, unshifting so the nearest level still wins per key.

Using `fetch` with a fallback block mirrors rspec-core exactly: it makes the walk correct whether handed example or group metadata, and avoids tripping the deprecated `:example_group`-on-group-metadata default proc.

### Tests

- Unit specs in `spec/rspec/shared_extractor_spec.rb`.
- Corrects the pre-existing Hanami golden (`spec/apps/hanami/doc/openapi.{yaml,json}`): `GET /tables` summary changes from the leaked `index` to the declared `Get a list of tables`. This is the only fixture change — the Rails fixtures don't use the pattern.