### PR TITLE
fix: cast boolean query parameters instead of typing them as string

### DIFF
--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -292,6 +292,9 @@ class << RSpec::OpenAPI::SchemaBuilder
 
   # Convert an always-String param to an appropriate type
   def try_cast(value)
+    return true if value == 'true'
+    return false if value == 'false'
+
     Integer(value)
   rescue TypeError, ArgumentError
     value

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -3404,6 +3404,15 @@
             "example": true
           },
           {
+            "name": "archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi.json
+++ b/spec/apps/rails/doc/rspec_openapi.json
@@ -3395,6 +3395,15 @@
             "example": "token"
           },
           {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -2086,6 +2086,12 @@ paths:
         schema:
           type: string
         example: token
+      - name: active
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: true
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/rspec_openapi.yaml
+++ b/spec/apps/rails/doc/rspec_openapi.yaml
@@ -2092,6 +2092,12 @@ paths:
         schema:
           type: boolean
         example: true
+      - name: archived
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: false
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/rspec_openapi_3.1.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.json
@@ -3549,6 +3549,15 @@
             "example": true
           },
           {
+            "name": "archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi_3.1.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.json
@@ -3540,6 +3540,15 @@
             "example": "token"
           },
           {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi_3.1.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.yaml
@@ -2186,6 +2186,12 @@ paths:
         schema:
           type: boolean
         example: true
+      - name: archived
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: false
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/rspec_openapi_3.1.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.1.yaml
@@ -2180,6 +2180,12 @@ paths:
         schema:
           type: string
         example: token
+      - name: active
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: true
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/rspec_openapi_3.2.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.json
@@ -3562,6 +3562,15 @@
             "example": true
           },
           {
+            "name": "archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi_3.2.json
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.json
@@ -3553,6 +3553,15 @@
             "example": "token"
           },
           {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
             "name": "filter[name]",
             "in": "query",
             "required": false,

--- a/spec/apps/rails/doc/rspec_openapi_3.2.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.yaml
@@ -2185,6 +2185,12 @@ paths:
         schema:
           type: string
         example: token
+      - name: active
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: true
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/rspec_openapi_3.2.yaml
+++ b/spec/apps/rails/doc/rspec_openapi_3.2.yaml
@@ -2191,6 +2191,12 @@ paths:
         schema:
           type: boolean
         example: true
+      - name: archived
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: false
       - name: filter[name]
         in: query
         required: false

--- a/spec/apps/rails/doc/smart/expected.yaml
+++ b/spec/apps/rails/doc/smart/expected.yaml
@@ -81,8 +81,8 @@ paths:
         in: query
         required: true
         schema:
-          type: string
-        example: "true"
+          type: boolean
+        example: true
       responses:
         '200':
           description: with flat query parameters

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Tables', type: :request do
   describe '#index', openapi: { summary: 'Get a list of tables' } do
     context 'returns a list of tables' do
       it 'with flat query parameters' do
-        get '/tables', params: { page: '1', per: '10', active: 'true' },
+        get '/tables', params: { page: '1', per: '10', active: 'true', archived: 'false' },
                        headers: { authorization: 'k0kubun', 'X-Authorization-Token': 'token' }
         expect(response.status).to eq(200)
       end

--- a/spec/requests/rails_spec.rb
+++ b/spec/requests/rails_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Tables', type: :request do
   describe '#index', openapi: { summary: 'Get a list of tables' } do
     context 'returns a list of tables' do
       it 'with flat query parameters' do
-        get '/tables', params: { page: '1', per: '10' },
+        get '/tables', params: { page: '1', per: '10', active: 'true' },
                        headers: { authorization: 'k0kubun', 'X-Authorization-Token': 'token' }
         expect(response.status).to eq(200)
       end


### PR DESCRIPTION
Fixes #380

## Problem

Boolean flags in a query string are typed as `string` in the generated schema. Given `GET /tables?active=true`, the parameter is recorded as `type: string, example: "true"` when it is really a boolean (`type: boolean, example: true`). Downstream, type generators like Orval then emit `string` for parameters the API treats as booleans, so callers pass `"true"` / `"false"` string literals instead of a boolean.

## Cause

Query params arrive as strings, but the gem does not treat them as opaque — `SchemaBuilder#try_cast` already recovers integers, so `?page=1` correctly generates `type: integer`. `try_cast` simply never had a branch for booleans, leaving the behaviour inconsistent: integer flags get their real type, boolean flags do not.

## Fix

Add the missing sibling branch to `try_cast`, casting the literal `"true"` / `"false"` to a boolean before the integer attempt:

```ruby
def try_cast(value)
  return true if value == 'true'
  return false if value == 'false'

  Integer(value)
rescue TypeError, ArgumentError
  value
end
```

This carries the same small, pre-existing trade-off the integer cast already makes — a param whose genuine value is the literal string `"1"` is cast to an integer today, and one whose value is literally `"true"` / `"false"` is now cast to a boolean. A query param reading `true` / `false` is virtually always a boolean flag. Happy to gate it behind an option if you would rather keep it opt-in.

## Testing

- Added a boolean query param (`active: 'true'`) to the existing rails flat-query spec; it now generates `type: boolean`. Golden yaml/json regenerated across 3.0 / 3.1 / 3.2.
- The smart-merge suite already sends `show_columns: true` to `/tables`, so its `expected.yaml` fixture updated too — a second, independent confirmation.
- All doc regeneration diffs are purely additive apart from the two `show_columns` type/example lines. hanami and minitest fixtures are unchanged (neither passes boolean-shaped query params).
- Full suite passes (63 examples, 0 failures).