### PR TITLE
Fix cleanup for operations with empty security

### DIFF
--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -101,9 +101,13 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
   end
 
   def remove_parameters_conflicting_with_security_scheme!(path_definition, security_scheme, security_scheme_name)
+    return unless path_definition
     return unless path_definition[:security]
     return unless path_definition[:parameters]
-    return unless path_definition.dig(:security, 0).keys.include?(security_scheme_name)
+
+    security_requirement = path_definition.dig(:security, 0)
+    return unless security_requirement.is_a?(Hash)
+    return unless security_requirement.key?(security_scheme_name)
 
     path_definition[:parameters].reject! do |parameter|
       parameter[:in] == security_scheme[:in] && # same location (ie. header)

--- a/spec/rspec/schema_cleaner_spec.rb
+++ b/spec/rspec/schema_cleaner_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rspec/openapi'
+
+RSpec.describe RSpec::OpenAPI::SchemaCleaner do
+  describe '.cleanup_conflicting_security_parameters!' do
+    let(:authorization_parameter) do
+      {
+        name: 'Authorization',
+        in: 'header',
+        required: true,
+        schema: { type: 'string' },
+      }
+    end
+
+    let(:security_schemes) do
+      {
+        'bearerAuth' => {
+          type: 'http',
+          scheme: 'bearer',
+          in: 'header',
+          name: 'Authorization',
+        },
+      }
+    end
+
+    it 'keeps parameters on operations that opt out of security with an empty array' do
+      spec = {
+        paths: {
+          :'/widgets/{id}' => {
+            get: {
+              security: [],
+              parameters: [authorization_parameter],
+              responses: { '200' => { description: 'ok' } },
+            },
+          },
+        },
+        components: {
+          securitySchemes: security_schemes,
+        },
+      }
+
+      expect { described_class.cleanup_conflicting_security_parameters!(spec) }.not_to raise_error
+      expect(spec.dig(:paths, :'/widgets/{id}', :get, :parameters)).to eq([authorization_parameter])
+    end
+
+    it 'removes parameters that duplicate the applied security scheme' do
+      spec = {
+        paths: {
+          :'/widgets/{id}' => {
+            get: {
+              security: [{ 'bearerAuth' => [] }],
+              parameters: [authorization_parameter],
+              responses: { '200' => { description: 'ok' } },
+            },
+          },
+        },
+        components: {
+          securitySchemes: security_schemes,
+        },
+      }
+
+      described_class.cleanup_conflicting_security_parameters!(spec)
+
+      expect(spec.dig(:paths, :'/widgets/{id}', :get)).not_to have_key(:parameters)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- handle operations that opt out of security with `security: []` without raising
- only remove conflicting parameters when the first security requirement is a hash containing the configured scheme
- add direct SchemaCleaner regression coverage for public operations with parameters and authenticated operations with duplicate auth parameters

Closes #382.

## Validation
- `docker run --rm -v "$PWD":/app -w /app ruby:3.3 bash -lc 'git config --global --add safe.directory /app && bundle install >/tmp/bundle-install.log && bundle exec rspec spec/rspec/schema_cleaner_spec.rb'`\n- `docker run --rm -v "$PWD":/app -w /app ruby:3.3 bash -lc 'ruby -c lib/rspec/openapi/schema_cleaner.rb && ruby -c spec/rspec/schema_cleaner_spec.rb'`\n- `git diff --check`\n\nI also ran `bundle exec rspec spec/rspec` in the same container. The new SchemaCleaner spec and other unit specs passed, but three existing fixture comparison examples failed on generated `info.title` differences (`app` vs `rspec-openapi`), which appear unrelated to this cleaner change. Generated fixture churn from that run was discarded.\n