### PR TITLE
ci: Record coverage from the specs that run in the worker

### DIFF
--- a/scripts/parallel_rspec
+++ b/scripts/parallel_rspec
@@ -48,7 +48,12 @@ abort('No spec files found') if files.empty?
 
 flags = args.reject { |arg| File.exist?(arg.sub(/[\[:]\d.*\z/, '')) }
 workers = Integer(ENV.fetch('RSPEC_WORKERS') { Etc.nprocessors }).clamp(1, files.size)
-rspec = Gem.bin_path('rspec-core', 'rspec')
+# Route the workers through the SimpleCov wrapper rather than rspec directly.
+# schema_file_spec, scheme_merger_spec and shared_extractor_spec exercise the
+# library in the worker itself rather than in a spawned app, so without this
+# nothing they cover is recorded. The wrapper and .simplecov_spawn both no-op
+# unless COVERAGE is set, so the other jobs are unaffected.
+rspec = File.expand_path('rspec_with_simplecov', __dir__)
 
 status_dir = File.join(Dir.tmpdir, "rspec-openapi-parallel-#{Process.pid}")
 FileUtils.mkdir_p(status_dir)
@@ -68,7 +73,7 @@ until queue.empty? && running.empty?
     # Each worker keeps its own example status file: RSpec rewrites the whole
     # file on exit, so sharing one would let the workers corrupt each other's.
     env = { 'RSPEC_STATUS_FILE' => File.join(status_dir, "#{File.basename(file)}.status") }
-    pid = Process.spawn(env, RbConfig.ruby, rspec, *flags, file, out: log, err: log)
+    pid = Process.spawn(env, RbConfig.ruby, rspec, '-r./.simplecov_spawn', *flags, file, out: log, err: log)
     running[pid] = [file, log]
   end
 


### PR DESCRIPTION
## Why

`spec/rspec/schema_file_spec.rb`, `spec/rspec/scheme_merger_spec.rb` and `spec/rspec/shared_extractor_spec.rb` exercise the library directly in the worker process rather than in a spawned Rails/Hanami/Roda app. Only the spawned apps load SimpleCov, so as far as the report is concerned those 35 examples cover nothing, and the code they exist to cover is reported as untested.

I noticed this while looking into the coverage drop on #412: a line flagged as uncovered had a spec exercising both of its branches.

## What

Route the workers through `scripts/rspec_with_simplecov`, exactly the way every spawned run already goes. The wrapper loads SimpleCov before rspec-core so the library is instrumented as it loads, which a plain `-r` cannot do because `.rspec` requires `rspec/openapi` first.

Measured against master with #412 merged:

| | before | after |
|---|---|---|
| lines | 98.73% (14 missed) | **99.18%** (9 missed) |
| branches | 87.16% | **89.26%** |

No spec changed, and no library code changed. This only stops discarding measurements we were already producing.

## Verified

- 12 spec files, 0 failures; every committed document still regenerates byte for byte.
- Both the wrapper and `.simplecov_spawn` no-op unless `COVERAGE` is set, so the seven jobs that do not collect coverage behave exactly as before and write no `coverage/` directory. Confirmed locally with `COVERAGE=` as well as `COVERAGE=coverage`.
- Rubocop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage reporting for parallel test runs.
  * Added support for collecting coverage from in-process specifications.
  * Coverage remains inactive when it is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->