### PR TITLE
refactor: Cover the library from the app runs, and drop what no run can reach

### DIFF
--- a/lib/rspec/openapi.rb
+++ b/lib/rspec/openapi.rb
@@ -131,10 +131,13 @@ module RSpec::OpenAPI
     # Allow Rails request specs to issue extra verbs (e.g. QUERY); ActionDispatch
     # otherwise rejects unknown verbs. No-op outside Rails.
     def register_http_methods(methods)
-      # simplecov:disable branch non-Rails guard for roda/hanami; the suite always loads Rails
+      # :nocov:
+      # Guards users without Rails. Every job here installs it, so this arm is
+      # unreachable from the suite. SimpleCov's token is `nocov`, so the marker
+      # this used to carry never actually excluded anything.
       return unless defined?(ActionDispatch::Request::HTTP_METHODS)
 
-      # simplecov:enable
+      # :nocov:
       Array(methods).each do |method|
         verb = method.to_s.upcase
         next if ActionDispatch::Request::HTTP_METHODS.include?(verb)
@@ -149,6 +152,9 @@ end
 if ENV['OPENAPI']
   RSpec::OpenAPI::Config.load_environment_settings
 
+  # :nocov:
+  # These two rescues report a framework the user does not have. Every job here
+  # installs both Hanami and Rails, so no run can reach them.
   begin
     require 'hanami'
   rescue LoadError
@@ -164,6 +170,7 @@ if ENV['OPENAPI']
   else
     require 'rspec/openapi/extractors/rails'
   end
+  # :nocov:
 end
 
 require 'rspec/openapi/minitest_hooks' if Object.const_defined?('Minitest')

--- a/lib/rspec/openapi/key_transformer.rb
+++ b/lib/rspec/openapi/key_transformer.rb
@@ -18,18 +18,16 @@ class << RSpec::OpenAPI::KeyTransformer = Object.new
     end
   end
 
+  # `examples` is a map of named examples under a media type, whose names are
+  # normalized here. Under a schema it is a JSON Schema keyword holding a plain
+  # array instead, which has no names to normalize.
   def symbolize_examples(value)
-    case value
-    when Hash
-      value.to_h do |k, v|
-        k = k.downcase.tr(' ', '_') unless k.is_a?(Symbol)
+    return symbolize(value) unless value.is_a?(Hash)
 
-        [k.to_sym, symbolize(v)]
-      end
-    when Array
-      value.map { |v| symbolize(v) }
-    else
-      value
+    value.to_h do |k, v|
+      k = k.downcase.tr(' ', '_') unless k.is_a?(Symbol)
+
+      [k.to_sym, symbolize(v)]
     end
   end
 

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -134,17 +134,15 @@ class << RSpec::OpenAPI::SchemaBuilder
     parameters&.empty? ? nil : parameters
   end
 
-  # `compound_name` and `required` follow from `location`:
-  # path/header params are always required and use bracketed names like
-  # `key[subkey]`; query params are pre-flattened and may be optional.
+  # Path and header params are always required; query params are pre-flattened
+  # by flatten_query_params and may be optional.
   def build_parameter(key, value, location:, record:)
     is_query = location == 'query'
-    compound_name = !is_query
     required = is_query ? record.required_request_params.include?(key) : true
     cast = try_cast(value)
     ctx = BuildContext.new(record: record, context: :request, key: key, path: key.to_s)
     {
-      name: compound_name ? build_parameter_name(key, value) : key,
+      name: key.to_s,
       in: location,
       required: required,
       schema: build_property(cast, ctx),
@@ -156,16 +154,6 @@ class << RSpec::OpenAPI::SchemaBuilder
     record.response_headers.to_h do |key, value|
       ctx = BuildContext.new(record: record, context: :response, key: key, path: key.to_s)
       [key, { schema: build_property(try_cast(value), ctx) }]
-    end
-  end
-
-  def build_parameter_name(key, value)
-    key = key.to_s
-    if value.is_a?(Hash) && (value_keys = value.keys).size == 1
-      value_key = value_keys.first
-      build_parameter_name("#{key}[#{value_key}]", value[value_key])
-    else
-      key
     end
   end
 

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -113,9 +113,9 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
     path_definition.delete(:parameters) if path_definition[:parameters].empty?
   end
 
-  def cleanup_array!(base, spec, selector, fields_for_identity = [])
+  def cleanup_array!(base, spec, selector, fields_for_identity)
     marshal = lambda do |obj|
-      Marshal.dump(slice(obj, fields_for_identity))
+      Marshal.dump(obj.slice(*fields_for_identity))
     end
 
     RSpec::OpenAPI::HashHelper.matched_paths(base, selector).each do |paths|
@@ -127,33 +127,20 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
       target_array.select! { |e| spec_identities.include?(marshal.call(e)) }
       target_array.sort_by! { |param| fields_for_identity.map { |f| param[f] }.join('-') }
       # Keep the last duplicate to produce the result stably
-      deduplicated = target_array.reverse.uniq { |param| slice(param, fields_for_identity) }.reverse
+      deduplicated = target_array.reverse.uniq { |param| param.slice(*fields_for_identity) }.reverse
       target_array.replace(deduplicated)
     end
     base
   end
 
+  # Every selector above names at least two segments, so a matched path always
+  # has a parent to delete the entry from.
   def cleanup_hash!(base, spec, selector)
     RSpec::OpenAPI::HashHelper.matched_paths(base, selector).each do |paths|
       exist_in_base = !base.dig(*paths).nil?
       not_in_spec = spec.dig(*paths).nil?
-      if exist_in_base && not_in_spec
-        if paths.size == 1
-          base.delete(paths.last)
-        else
-          parent_node = base.dig(*paths[0..-2])
-          parent_node.delete(paths.last)
-        end
-      end
+      base.dig(*paths[0..-2]).delete(paths.last) if exist_in_base && not_in_spec
     end
     base
-  end
-
-  def slice(obj, fields_for_identity)
-    if fields_for_identity.any?
-      obj.slice(*fields_for_identity)
-    else
-      obj
-    end
   end
 end

--- a/spec/apps/rails/doc/broken_config/openapi.yaml
+++ b/spec/apps/rails/doc/broken_config/openapi.yaml
@@ -1,0 +1,25 @@
+---
+openapi: 3.2.0
+info:
+  title: OpenAPI Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/example_mode_single":
+    get:
+      summary: GET /example_mode_single
+      tags: []
+      responses:
+        '200':
+          description: still records the request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                required:
+                - status
+              example:
+                status: single

--- a/spec/apps/rails/doc/broken_config/rspec_openapi.rb
+++ b/spec/apps/rails/doc/broken_config/rspec_openapi.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Deliberately broken. A per-directory config file is loaded next to the
+# document it configures, and a mistake in one must not take the whole suite
+# down with it: rspec-openapi warns and carries on writing the document.
+# spec/requests/rails_broken_config_spec.rb covers that.
+raise 'boom from a per-directory config file'

--- a/spec/apps/rails/doc/config/openapi.yaml
+++ b/spec/apps/rails/doc/config/openapi.yaml
@@ -1,0 +1,100 @@
+# This file is auto-generated. Edits are preserved where possible.
+---
+openapi: 3.2.0
+info:
+  title: OpenAPI Documentation for request
+  version: 1.0.0
+  x-request-count: 2
+servers: []
+paths:
+  "/example_mode_multiple":
+    get:
+      summary: GET /example_mode_multiple
+      tags: []
+      responses:
+        '200':
+          description: records a response in :multiple example mode
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                required:
+                - status
+              examples:
+                records_a_response_in_:multiple_example_mode:
+                  value:
+                    status: multiple
+  "/tables/{id}":
+    get:
+      summary: show
+      tags:
+      - Table
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 1
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+        example: 1
+      responses:
+        '200':
+          description: records a table with path and query parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  database:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                  null_sample:
+                    type: 'null'
+                  storage_size:
+                    type: number
+                    format: float
+                  created_at:
+                    type: string
+                  updated_at:
+                    type: string
+                required:
+                - id
+                - name
+                - description
+                - database
+                - null_sample
+                - storage_size
+                - created_at
+                - updated_at
+              example:
+                id: 1
+                name: access
+                description: logs
+                database:
+                  id: 2
+                  name: production
+                null_sample:
+                storage_size: 12.3
+                created_at: '2020-07-17T00:00:00+00:00'
+                updated_at: '2020-07-17T00:00:00+00:00'

--- a/spec/apps/rails/doc/no_example/openapi.yaml
+++ b/spec/apps/rails/doc/no_example/openapi.yaml
@@ -1,0 +1,130 @@
+---
+openapi: 3.2.0
+info:
+  title: OpenAPI Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/tables":
+    post:
+      summary: create
+      tags:
+      - Table
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+              required:
+              - name
+              - description
+      responses:
+        '201':
+          description: records a request body without an example value
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  database:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                  null_sample:
+                    type: 'null'
+                  storage_size:
+                    type: number
+                    format: float
+                  created_at:
+                    type: string
+                  updated_at:
+                    type: string
+                required:
+                - id
+                - name
+                - description
+                - database
+                - null_sample
+                - storage_size
+                - created_at
+                - updated_at
+  "/tables/{id}":
+    get:
+      summary: show
+      tags:
+      - Table
+      parameters:
+      - name: X-Authorization-Token
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: records path and query parameters without example values
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  database:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                  null_sample:
+                    type: 'null'
+                  storage_size:
+                    type: number
+                    format: float
+                  created_at:
+                    type: string
+                  updated_at:
+                    type: string
+                required:
+                - id
+                - name
+                - description
+                - database
+                - null_sample
+                - storage_size
+                - created_at
+                - updated_at

--- a/spec/apps/rails/doc/roundtrip/input.yaml
+++ b/spec/apps/rails/doc/roundtrip/input.yaml
@@ -45,3 +45,8 @@ paths:
                     type:
                     - string
                     - integer
+                    # `examples` under a schema is the JSON Schema keyword: a
+                    # plain array, not the named map it is under a media type.
+                    examples:
+                    - a string
+                    - 42

--- a/spec/requests/rails_3_2_roundtrip_spec.rb
+++ b/spec/requests/rails_3_2_roundtrip_spec.rb
@@ -8,9 +8,10 @@ require File.expand_path('../apps/rails/config/environment', __dir__)
 require 'rspec/rails'
 
 # Re-records over a hand-edited 3.2 document. The untouched entries exercise the
-# read-side normalization: /legacy carries JSON-Schema null type arrays, and
-# /weird_non_hash is a non-object path item the converters must skip. Both are
-# dropped from the output (as any un-recorded path is).
+# read-side normalization: /legacy carries JSON-Schema null type arrays and an
+# `examples` array under a schema, and /weird_non_hash is a non-object path item
+# the converters must skip. All are dropped from the output (as any un-recorded
+# path is).
 RSpec::OpenAPI.title = 'Round-trip'
 RSpec::OpenAPI.openapi_version = '3.2.0'
 RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/roundtrip/input.yaml', __dir__)

--- a/spec/requests/rails_broken_config_spec.rb
+++ b/spec/requests/rails_broken_config_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# The document directory holds a config file that raises on load. rspec-openapi
+# should warn about it and still write the document.
+RSpec::OpenAPI.title = 'OpenAPI Documentation'
+RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/broken_config/openapi.yaml', __dir__)
+
+RSpec.describe 'a broken per-directory config file', type: :request do
+  it 'still records the request' do
+    get '/example_mode_single'
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/rails_config_spec.rb
+++ b/spec/requests/rails_config_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# Exercises the settings that accept something other than a plain value:
+# `title` and `path` may be procs resolved per example, `post_process_hook`
+# gets the last word on the built document, and a `comment` without a trailing
+# newline has to be terminated before it is turned into YAML comment lines.
+# `enable_example_summary` is off here so summaries are left out of `examples`.
+RSpec::OpenAPI.title = ->(example) { "OpenAPI Documentation for #{example.metadata[:type]}" }
+RSpec::OpenAPI.path = lambda { |_example|
+  File.expand_path('../apps/rails/doc/config/openapi.yaml', __dir__)
+}
+RSpec::OpenAPI.comment = 'This file is auto-generated. Edits are preserved where possible.'
+RSpec::OpenAPI.enable_example_summary = false
+RSpec::OpenAPI.post_process_hook = lambda { |_path, records, spec|
+  spec[:info][:'x-request-count'] = records.size
+}
+
+RSpec.describe 'configuration accepting procs and hooks', type: :request do
+  it 'records a response in :multiple example mode', openapi: { example_mode: :multiple } do
+    get '/example_mode_multiple'
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'records a table with path and query parameters' do
+    get '/tables/1', params: { page: 1 }, headers: { authorization: 'k0kubun' }
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/rails_invalid_example_mode_spec.rb
+++ b/spec/requests/rails_invalid_example_mode_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# `example_mode` only accepts a Symbol or String naming a mode, or a Hash of
+# :request/:response. Anything else aborts the example with a message naming
+# both the value and the example it came from, rather than recording something
+# the user did not ask for. The document is never written, so this spec points
+# at a path under tmp.
+RSpec::OpenAPI.title = 'OpenAPI Documentation'
+RSpec::OpenAPI.path = File.expand_path('../apps/rails/tmp/invalid_example_mode.yaml', __dir__)
+
+RSpec.describe 'invalid example_mode', type: :request do
+  it 'aborts the example', openapi: { example_mode: 42 } do
+    get '/example_mode_single'
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/rails_no_example_spec.rb
+++ b/spec/requests/rails_no_example_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# With `enable_example` off, nothing recorded carries a sample value: neither
+# the parameters nor the request body get an `example`, only their schemas.
+RSpec::OpenAPI.title = 'OpenAPI Documentation'
+RSpec::OpenAPI.enable_example = false
+RSpec::OpenAPI.request_headers = ['X-Authorization-Token']
+RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/no_example/openapi.yaml', __dir__)
+
+RSpec.describe 'documents without examples', type: :request do
+  it 'records path and query parameters without example values' do
+    get '/tables/1', params: { page: 1 }, headers: { authorization: 'k0kubun', 'X-Authorization-Token': 'token' }
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'records a request body without an example value' do
+    post '/tables', params: { name: 'Table', description: 'A table' },
+                    headers: { authorization: 'k0kubun' }, as: :json
+    expect(response).to have_http_status(:created)
+  end
+end

--- a/spec/rspec/rails_config_spec.rb
+++ b/spec/rspec/rails_config_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe 'rails request spec, configuration' do
     end
   end
 
+  describe 'enable_example turned off' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/no_example/openapi.yaml', repo_root)
+    end
+
+    it 'generates the committed no_example/openapi.yaml' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_no_example_spec.rb', openapi: true, output: :yaml
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+
+    it 'leaves example values out of parameters and the request body' do
+      expect(File.read(openapi_path)).not_to include('example:')
+    end
+  end
+
   describe 'an invalid example_mode' do
     it 'aborts the example naming both the value and the example' do
       out, err, status = rspec_capture 'spec/requests/rails_invalid_example_mode_spec.rb', openapi: true, output: :yaml

--- a/spec/rspec/rails_config_spec.rb
+++ b/spec/rspec/rails_config_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe 'rails request spec, configuration' do
     end
   end
 
+  describe 'DEBUG in the environment' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/config/openapi.yaml', repo_root)
+    end
+
+    # DEBUG is read once while rspec-openapi loads, so it has to be set for the
+    # spawned run rather than from inside the spec.
+    it 'records the same document as a run without it' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_config_spec.rb', openapi: true, output: :yaml, debug: true
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+  end
+
   describe 'a per-directory config file that raises' do
     let(:openapi_path) do
       File.expand_path('spec/apps/rails/doc/broken_config/openapi.yaml', repo_root)

--- a/spec/rspec/rails_config_spec.rb
+++ b/spec/rspec/rails_config_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, configuration' do
+  include SpecHelper
+
+  describe 'settings that take a proc or a hook' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/config/openapi.yaml', repo_root)
+    end
+
+    it 'resolves title and path per example, runs the post process hook and terminates the comment' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_config_spec.rb', openapi: true, output: :yaml
+      new_yaml = YAML.safe_load(File.read(openapi_path))
+      expect(new_yaml).to eq org_yaml
+    end
+
+    it 'writes the comment as its own line even though the configured one has no newline' do
+      expect(File.read(openapi_path).lines.first)
+        .to eq("# This file is auto-generated. Edits are preserved where possible.\n")
+    end
+
+    it 'leaves summaries out of examples when enable_example_summary is off' do
+      operation = YAML.safe_load(File.read(openapi_path)).dig('paths', '/example_mode_multiple', 'get')
+      examples = operation.dig('responses', '200', 'content', 'application/json', 'examples')
+      expect(examples.values.map(&:keys)).to eq([['value']])
+    end
+  end
+
+  describe 'an invalid example_mode' do
+    it 'aborts the example naming both the value and the example' do
+      out, err, status = rspec_capture 'spec/requests/rails_invalid_example_mode_spec.rb', openapi: true, output: :yaml
+      expect(status.success?).to eq(false)
+      expect(out + err).to include(
+        'example_mode must be a Symbol/String in [:none, :single, :multiple] or a Hash with ' \
+        ':request/:response keys, got 42 (example: invalid example_mode aborts the example)',
+      )
+    end
+  end
+
+  describe 'a per-directory config file that raises' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/broken_config/openapi.yaml', repo_root)
+    end
+
+    it 'warns and still writes the document' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      out, = rspec 'spec/requests/rails_broken_config_spec.rb', openapi: true, output: :yaml
+      expect(out).to include('WARNING: Unable to load')
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,39 +15,41 @@ module SpecHelper
   end
 
   # Run inside the repo with the gem bundle, asserting the run succeeds.
-  def run_tests(*args, command:, openapi: false, output: :yaml, openapi_version: nil)
-    within_test_run(*args, command: command, openapi: openapi, output: output,
-                           openapi_version: openapi_version,) { |argv| assert_run(*argv) }
+  # Options shape the spawned run's environment; see within_test_run.
+  def run_tests(*args, command:, **options)
+    within_test_run(*args, command: command, **options) { |argv| assert_run(*argv) }
   end
 
   # Same as run_tests, but returns [out, err, status] without asserting success,
   # so negative cases can assert on a run that is expected to abort.
-  def capture_tests(*args, command:, openapi: false, output: :yaml, openapi_version: nil)
-    within_test_run(*args, command: command, openapi: openapi, output: output,
-                           openapi_version: openapi_version,) { |argv| Open3.capture3(*argv) }
+  def capture_tests(*args, command:, **options)
+    within_test_run(*args, command: command, **options) { |argv| Open3.capture3(*argv) }
   end
 
-  def rspec(*args, openapi: false, output: :yaml, openapi_version: nil)
-    run_tests(*args, command: 'scripts/rspec_with_simplecov', openapi: openapi, output: output,
-                     openapi_version: openapi_version,)
+  def rspec(*args, **options)
+    run_tests(*args, command: 'scripts/rspec_with_simplecov', **options)
   end
 
-  def rspec_capture(*args, openapi: false, output: :yaml, openapi_version: nil)
-    capture_tests(*args, command: 'scripts/rspec_with_simplecov', openapi: openapi, output: output,
-                         openapi_version: openapi_version,)
+  def rspec_capture(*args, **options)
+    capture_tests(*args, command: 'scripts/rspec_with_simplecov', **options)
   end
 
-  def minitest(*args, openapi: false, output: :yaml, openapi_version: nil)
-    run_tests(*args, command: 'ruby', openapi: openapi, output: output, openapi_version: openapi_version)
+  def minitest(*args, **options)
+    run_tests(*args, command: 'ruby', **options)
   end
 
   private
 
-  def within_test_run(*args, command:, openapi:, output:, openapi_version:)
+  # @param options [Hash] :openapi enables generation, :output picks yaml/json/both,
+  #   :openapi_version pins the document version, :debug turns on rspec-openapi's
+  #   own diagnostics. All of them are read while the child boots, which is why
+  #   they travel as environment rather than as configuration in the spec.
+  def within_test_run(*args, command:, **options)
     env = {
-      'OPENAPI' => ('1' if openapi),
-      'OPENAPI_OUTPUT' => output.to_s,
-      'OPENAPI_VERSION' => openapi_version,
+      'OPENAPI' => ('1' if options[:openapi]),
+      'OPENAPI_OUTPUT' => options.fetch(:output, :yaml).to_s,
+      'OPENAPI_VERSION' => options[:openapi_version],
+      'DEBUG' => ('1' if options[:debug]),
     }.compact
     Bundler.public_send(Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env) do
       Dir.chdir(repo_root) do


### PR DESCRIPTION
Coverage now comes from spawned Rails runs rather than from asserting on the library in-process, per the brief. No unit spec was added.

## Numbers

Codecov counts a line with any uncovered branch as not covered, which is the number to go by:

| | master | this PR |
|---|---|---|
| **Codecov coverage** | 95.10% | **97.12%** |
| lines never executed (Misses) | 9 | **0** |
| lines with an uncovered branch (Partials) | 45 | 31 |

An earlier revision of this description led with "lines 100.00%". That was Cobertura's line-rate, which counts a line as covered once it executes at all — it is the Misses row above, not a claim that everything is covered. 31 lines still have a branch that no run takes.

Note the coverage job runs Ruby 4.0 / Rails 8.1.2, so a couple of version-dependent branches land differently there than when measuring locally on another combination. Codecov's figure is the one that counts.

## New app runs

Four spawned runs against the Rails app, each committing the document it generates so a regression shows up as a document diff:

- **`rails_config_spec`** — `title` and `path` as procs resolved per example, a `post_process_hook` that gets the last word on the document, a `comment` with no trailing newline (which has to be terminated before it becomes YAML comment lines), and `enable_example_summary` off. Also runs once more with `DEBUG` set, which is read while rspec-openapi loads and so had to be passed to the child rather than set in the spec.
- **`rails_no_example_spec`** — `enable_example` off, with both a request carrying path and query parameters and one carrying a JSON body, so both places that ask `example_enabled?` before building a value are exercised.
- **`rails_invalid_example_mode_spec`** — `example_mode` metadata that is not a mode at all. The example must abort naming both the value and the example it came from.
- **`rails_broken_config_spec`** — a document directory holding a per-directory config file that raises. rspec-openapi warns and still writes the document.

The hand-edited round-trip fixture also gained an `examples` array under a schema. That is the JSON Schema keyword rather than the named map used at the media type level, and it is what makes `symbolize_examples` take its non-map arm for real.

## Dead code

- **`build_parameter_name`** — nested query parameters have been flattened before reaching it since #305, and path and header parameter values are always strings, so its recursive arm was unreachable. For every remaining caller the name it produced was the key itself.
- **`cleanup_hash!`'s one-segment branch** — the shortest selector it is ever given names two segments, so a matched path always has a parent.
- **`slice`** — returned the object untouched when asked for no identity fields, but its one caller always asks for `:name` and `:in`. Dropping the default argument makes that a contract rather than a hidden case.
- **`symbolize_examples`'s Array and scalar arms** — repeated what `symbolize` already does for those types; it now delegates.

## Two guards that genuinely cannot be reached

`register_http_methods` protects users without Rails, and the two `rescue LoadError` arms report a framework the user does not have. Every job installs both Hanami and Rails.

The first already carried a marker saying so — but SimpleCov's token is `nocov` and the marker read `simplecov:disable`, so **it had never excluded anything**. Both now use the real token and say what would have to change to reach them.

## Verified

- 13 spec files, 0 failures; every committed document regenerates byte for byte.
- Ruby 2.7 / Rails 6.1.6 in a container: 0 failures and no keyword-argument deprecation warnings from the `spec_helper` change, which now threads spawn options as one hash (five keywords had grown past what Rubocop allows).
- Rubocop reports the same 4 pre-existing offenses as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenAPI documentation now uses clearer parameter names, more accurate schemas, and improved handling of nested and array data.
  * Added support for generating documentation without example values.
  * Improved configuration handling, including custom titles, output paths, post-processing, and multiple response examples.
  * Invalid example settings now fail clearly while preserving the underlying request response.

* **Documentation**
  * Added comprehensive OpenAPI examples for table endpoints, parameters, responses, and authorization headers.

* **Tests**
  * Expanded coverage for Rails integrations, configuration recovery, generated output, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->