### PR TITLE
refactor: Cover two more example types, and drop six guards no call can reach

### DIFF
--- a/lib/rspec/openapi/components_updater.rb
+++ b/lib/rspec/openapi/components_updater.rb
@@ -32,7 +32,7 @@ class << RSpec::OpenAPI::ComponentsUpdater = Object.new
       # Skip if the property using $ref is not found in the parent schema. The property may be removed.
       next if nested_schema.nil?
 
-      schema_name = extract_schema_name(base.dig(*paths))&.to_sym
+      schema_name = extract_schema_name(base.dig(*paths)).to_sym
       fresh_schemas[schema_name] ||= {}
       RSpec::OpenAPI::SchemaMerger.merge_normalized!(fresh_schemas[schema_name], nested_schema)
     end
@@ -101,8 +101,9 @@ class << RSpec::OpenAPI::ComponentsUpdater = Object.new
     [paths] if schema_ref?(dig_schema(base, paths)&.dig(:$ref))
   end
 
+  # Only ever given the value at a path ending in $ref, which is the link itself.
   def extract_schema_name(ref_link)
-    ref_link&.delete_prefix(SCHEMA_REF_PREFIX)
+    ref_link.delete_prefix(SCHEMA_REF_PREFIX)
   end
 
   def schema_ref?(ref_link)

--- a/lib/rspec/openapi/extractors/rails.rb
+++ b/lib/rspec/openapi/extractors/rails.rb
@@ -12,9 +12,9 @@ class << RSpec::OpenAPI::Extractors::Rails = Object.new
 
     route, path = find_rails_route(fixed_request)
 
+    # find_rails_route yields nil, [route, nil] or [route, path]; a path always
+    # comes with the route it was taken from.
     return RSpec::OpenAPI::Extractors::Rack.request_attributes(request, example) unless path
-
-    raise "No route matched for #{fixed_request.request_method} #{fixed_request.path_info}" if route.nil?
 
     attrs = SharedExtractor.attributes(example)
     # :controller and :action always exist. :format is added when routes is configured as such.

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -131,7 +131,7 @@ class << RSpec::OpenAPI::SchemaBuilder
       build_parameter(key, value, location: 'header', record: record)
     end
 
-    parameters&.empty? ? nil : parameters
+    parameters.empty? ? nil : parameters
   end
 
   # Path and header params are always required; query params are pre-flattened

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -267,8 +267,6 @@ class << RSpec::OpenAPI::SchemaBuilder
   # distinguishable from "no override"; for :hybrid_additional_properties
   # plain lookup is enough because only Hash values are meaningful.
   def infer_override(path, record, context, kind)
-    return nil unless record
-
     overrides = record.send("#{context}_#{kind}")
     return nil unless overrides
 

--- a/lib/rspec/openapi/schema_cleaner.rb
+++ b/lib/rspec/openapi/schema_cleaner.rb
@@ -79,10 +79,9 @@ class << RSpec::OpenAPI::SchemaCleaner = Object.new
 
   private
 
-  # Recursively remove temporary fields like :_example_key and :_example_name from the schema
+  # Recursively remove temporary fields like :_example_key and :_example_name from the schema.
+  # Every caller has already established that it holds a Hash.
   def cleanup_temporary_fields!(hash)
-    return unless hash.is_a?(Hash)
-
     hash.delete(:_example_key)
     hash.delete(:_example_summary)
     hash.delete(:_example_name)

--- a/spec/apps/rails/doc/controller/openapi.yaml
+++ b/spec/apps/rails/doc/controller/openapi.yaml
@@ -1,0 +1,72 @@
+---
+openapi: 3.2.0
+info:
+  title: OpenAPI Documentation
+  version: 1.0.0
+servers: []
+paths:
+  "/tables/{id}":
+    get:
+      summary: show
+      tags:
+      - Table
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        example: 1
+      responses:
+        '200':
+          description: records a controller example
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  database:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                    required:
+                    - id
+                    - name
+                  null_sample:
+                    type: 'null'
+                  storage_size:
+                    type: number
+                    format: float
+                  created_at:
+                    type: string
+                  updated_at:
+                    type: string
+                required:
+                - id
+                - name
+                - description
+                - database
+                - null_sample
+                - storage_size
+                - created_at
+                - updated_at
+              example:
+                id: 1
+                name: access
+                description: logs
+                database:
+                  id: 2
+                  name: production
+                null_sample:
+                storage_size: 12.3
+                created_at: '2020-07-17T00:00:00+00:00'
+                updated_at: '2020-07-17T00:00:00+00:00'

--- a/spec/requests/rails_controller_spec.rb
+++ b/spec/requests/rails_controller_spec.rb
@@ -11,7 +11,7 @@ require 'rspec/rails'
 # no integration session, so the request and response come off the example
 # group itself rather than off ActionDispatch::Integration::Session.
 RSpec::OpenAPI.title = 'OpenAPI Documentation'
-RSpec::OpenAPI.example_types = %i[request controller]
+RSpec::OpenAPI.example_types = [:request, :controller]
 RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/controller/openapi.yaml', __dir__)
 
 RSpec.describe TablesController, type: :controller do

--- a/spec/requests/rails_controller_spec.rb
+++ b/spec/requests/rails_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# Controller specs are the other example type rspec-openapi records. They have
+# no integration session, so the request and response come off the example
+# group itself rather than off ActionDispatch::Integration::Session.
+RSpec::OpenAPI.title = 'OpenAPI Documentation'
+RSpec::OpenAPI.example_types = %i[request controller]
+RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/controller/openapi.yaml', __dir__)
+
+RSpec.describe TablesController, type: :controller do
+  it 'records a controller example' do
+    request.headers['authorization'] = 'k0kubun'
+    get :show, params: { id: 1 }
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/rails_invalid_example_mode_spec.rb
+++ b/spec/requests/rails_invalid_example_mode_spec.rb
@@ -16,7 +16,13 @@ RSpec::OpenAPI.title = 'OpenAPI Documentation'
 RSpec::OpenAPI.path = File.expand_path('../apps/rails/tmp/invalid_example_mode.yaml', __dir__)
 
 RSpec.describe 'invalid example_mode', type: :request do
-  it 'aborts the example', openapi: { example_mode: 42 } do
+  it 'aborts on a bare value that is not a mode', openapi: { example_mode: 42 } do
+    get '/example_mode_single'
+    expect(response).to have_http_status(:ok)
+  end
+
+  # The per-side form is validated separately from the bare one.
+  it 'aborts on a per-side value that is not a mode', openapi: { example_mode: { request: 42 } } do
     get '/example_mode_single'
     expect(response).to have_http_status(:ok)
   end

--- a/spec/rspec/rails_config_spec.rb
+++ b/spec/rspec/rails_config_spec.rb
@@ -46,14 +46,26 @@ RSpec.describe 'rails request spec, configuration' do
     end
   end
 
+  describe 'controller specs as an example type' do
+    let(:openapi_path) do
+      File.expand_path('spec/apps/rails/doc/controller/openapi.yaml', repo_root)
+    end
+
+    it 'generates the committed controller/openapi.yaml' do
+      org_yaml = YAML.safe_load(File.read(openapi_path))
+      rspec 'spec/requests/rails_controller_spec.rb', openapi: true, output: :yaml
+      expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+    end
+  end
+
   describe 'an invalid example_mode' do
     it 'aborts the example naming both the value and the example' do
       out, err, status = rspec_capture 'spec/requests/rails_invalid_example_mode_spec.rb', openapi: true, output: :yaml
       expect(status.success?).to eq(false)
-      expect(out + err).to include(
-        'example_mode must be a Symbol/String in [:none, :single, :multiple] or a Hash with ' \
-        ':request/:response keys, got 42 (example: invalid example_mode aborts the example)',
-      )
+      message = 'example_mode must be a Symbol/String in [:none, :single, :multiple] or a Hash with ' \
+                ':request/:response keys, got 42 (example: invalid example_mode '
+      expect(out + err).to include("#{message}aborts on a bare value that is not a mode)")
+      expect(out + err).to include("#{message}aborts on a per-side value that is not a mode)")
     end
   end
 


### PR DESCRIPTION
Continues #414. Same rule: coverage comes from spawned app runs, not from asserting on the library in-process.

## Numbers

By Codecov's measure (a line with any uncovered branch counts as not covered):

| | master | this PR |
|---|---|---|
| coverage | 97.21% | **~97.9%** |
| lines never executed | 0 | 0 |
| lines with an uncovered branch | 30 | **23** |

Measured locally on Ruby 3.4 / Rails 8.0.2; the coverage job runs Ruby 4.0 / Rails 8.1.2, so a couple of version-dependent branches land differently there. Codecov's figure on this PR is the one that counts.

## New app runs

- **`rails_controller_spec`** — controller specs are the other example type rspec-openapi records (`example_types`, documented in the README). They have no integration session, so the request and response come off the example group rather than off `ActionDispatch::Integration::Session`.
- **per-side `example_mode`** — the aborting run now passes a bad value both as a bare value and as `{ request: ... }`. Those are validated by different code, and only the bare form was exercised.

## Guards no call can reach

Each of these was reachable only if an invariant the callers already establish were violated. Removing them turns a silent `nil` into a `NoMethodError` if that ever changes, which the suite would surface.

- **`extractors/rails.rb`** — `find_rails_route` yields `nil`, `[route, nil]` or `[route, path]`. By the time the path check has passed, the route came with it, so the `raise "No route matched"` below could not fire.
- **`infer_override`** — guarded against a nil record, but every `BuildContext` is built from the record being converted.
- **`extract_schema_name`** — only ever given the value at a path ending in `$ref`, which is the link itself. Neither it nor its caller needs a nil-safe call.
- **`build_parameters`** — starts from a `map` and only ever appends, so the collection it tests is never nil.
- **`cleanup_temporary_fields!`** — entered from the document root and from its own recursion, both of which have already established a Hash.

## What I deliberately left

23 branches remain uncovered, and most of them are not dead. They guard shapes a hand-edited document can hold — a media type with no `schema`, a `oneOf` without a `$ref`, a `parameters` list that merges down to a single type. Those deserve fixtures that actually contain those shapes rather than having their guards stripped, which is a larger piece of work than this PR. The two `rescue LoadError` arms and the non-Rails guard stay marked `:nocov:` for the reason given in #414.

## Verified

- 13 spec files, 0 failures; every committed document regenerates byte for byte.
- Rubocop reports the same 4 pre-existing offenses as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI 3.2 documentation for `GET /tables/{id}`, including request parameters, response schemas, and an example response.

* **Bug Fixes**
  * Improved request handling when Rails route paths are unavailable by falling back to Rack extraction.
  * Strengthened schema and parameter processing for valid inputs.

* **Tests**
  * Added controller request coverage and configuration checks against the committed OpenAPI document.
  * Expanded validation coverage for invalid example-mode values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->