### PR TITLE
refactor: Cover the hand-edited document guards with a fixture that holds those shapes

### DIFF
--- a/spec/apps/rails/doc/hand_edited/openapi.yaml
+++ b/spec/apps/rails/doc/hand_edited/openapi.yaml
@@ -1,0 +1,44 @@
+---
+openapi: 3.2.0
+info:
+  title: Hand edited
+  version: 1.0.0
+servers: []
+paths:
+  "/example_mode_single":
+    get:
+      summary: GET /example_mode_single
+      tags: []
+      responses:
+        '200':
+          description: records over them without disturbing them
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                required:
+                - status
+              example:
+                status: single
+        '409':
+          description: written by hand, mixed oneOf
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - "$ref": "#/components/schemas/HandEditedConflict"
+                -
+                - type: object
+                  properties:
+                    reason:
+                      type: string
+        '503':
+          description: written by hand, no schema
+          content:
+            application/json: {}
+components:
+  schemas:
+    HandEditedConflict:

--- a/spec/requests/rails_hand_edited_spec.rb
+++ b/spec/requests/rails_hand_edited_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+ENV['TZ'] ||= 'UTC'
+ENV['RAILS_ENV'] ||= 'test'
+ENV['OPENAPI_OUTPUT'] ||= 'yaml'
+
+require File.expand_path('../apps/rails/config/environment', __dir__)
+require 'rspec/rails'
+
+# Re-records over a document holding shapes only a person writes. Response codes
+# are never cleaned up, so the hand-written ones in the fixture survive the run
+# and the scan for referenced components has to cope with them:
+#
+#   '503' has a media type with no schema at all, where that scan looks for one.
+#   '409' has a oneOf mixing a $ref, a list item left empty mid-edit, and an
+#         inline schema, so the scan meets all three.
+#
+# The component the 409 refers to comes out empty, because nothing recorded
+# fills it in. The fixture pins that as it stands today.
+RSpec::OpenAPI.title = 'Hand edited'
+RSpec::OpenAPI.openapi_version = '3.2.0'
+RSpec::OpenAPI.path = File.expand_path('../apps/rails/doc/hand_edited/openapi.yaml', __dir__)
+
+RSpec.describe 'hand-edited document shapes', type: :request do
+  it 'records over them without disturbing them' do
+    get '/example_mode_single'
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/rspec/rails_hand_edited_spec.rb
+++ b/spec/rspec/rails_hand_edited_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+RSpec.describe 'rails request spec, hand-edited document shapes' do
+  include SpecHelper
+
+  let(:openapi_path) do
+    File.expand_path('spec/apps/rails/doc/hand_edited/openapi.yaml', repo_root)
+  end
+
+  it 'generates the committed hand_edited/openapi.yaml' do
+    org_yaml = YAML.safe_load(File.read(openapi_path))
+    rspec 'spec/requests/rails_hand_edited_spec.rb', openapi: true, output: :yaml
+    expect(YAML.safe_load(File.read(openapi_path))).to eq org_yaml
+  end
+
+  it 'keeps the hand-written response codes the recording never touches' do
+    responses = YAML.safe_load(File.read(openapi_path)).dig('paths', '/example_mode_single', 'get', 'responses')
+    expect(responses.keys).to contain_exactly('200', '409', '503')
+    expect(responses.dig('503', 'content', 'application/json')).to eq({})
+    one_of = responses.dig('409', 'content', 'application/json', 'schema', 'oneOf')
+    expect(one_of.first).to eq({ '$ref' => '#/components/schemas/HandEditedConflict' })
+    # A list item left empty mid-edit. The scan for referenced components has to
+    # step over it rather than ask a nil for its $ref.
+    expect(one_of[1]).to be_nil
+  end
+end


### PR DESCRIPTION
Continues #415. #415 left 22 uncovered branches and said most of them were not dead — they guard shapes a hand-edited document can hold, and deserved a fixture containing those shapes rather than having their guards stripped. This is that fixture.

## Numbers

By Codecov's measure:

| | master | this PR |
|---|---|---|
| coverage | 97.95% | **~98.1%** |
| lines with an uncovered branch | 22 | **20** |

Measured locally on Ruby 3.4 / Rails 8.0.2; the coverage job runs Ruby 4.0 / Rails 8.1.2, so Codecov's figure on this PR is the one that counts.

## The fixture

`spec/apps/rails/doc/hand_edited/openapi.yaml` is re-recorded over by `rails_hand_edited_spec`. Response codes have no cleanup selector, so hand-written ones survive a run untouched, and the scan for referenced components has to walk them:

- **`'503'` has a media type with no `schema` at all**, where that scan looks for one. `ComponentsUpdater` reached for `:schema` under every recorded media type; nothing in the suite had a media type without one.
- **`'409'` has a `oneOf` mixing a `$ref`, a list item left empty mid-edit, and an inline schema**, so the scan meets all three kinds of member. The empty item is what a partially typed YAML list gives you, and it is exactly the shape the nil-safe call there exists for.

The component the 409 refers to comes out empty, because nothing recorded fills it in. The fixture pins that as it stands rather than asserting it is right.

## What is still uncovered, and why I stopped

20 branches. I tried and rejected a fixture for two of them, which is worth recording:

- **`merge_closest_match!`'s nil option** needs `oneOf: []` in the document when it is read. Putting it there works exactly once: the run pushes the recorded schema into it, so the committed fixture then holds a one-element `oneOf` and the next run never sees an empty one. A fixture cannot hold this shape across a re-record.
- **`build_request_body`'s nil media type** needs a recorded request with no `Content-Type`. Both Rails' integration session and Rack::Test set a default, so no request through either app produces one.

The rest are similar: reachable in principle, but only from a shape that either cannot survive a re-record or that neither app can produce. They are guards worth keeping, not dead code. The two `rescue LoadError` arms and the non-Rails guard stay marked `:nocov:` for the reason given in #414.

## Verified

- 14 spec files, 0 failures; every committed document regenerates byte for byte, including the new one across repeated runs.
- Rubocop reports the same 4 pre-existing offenses as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an OpenAPI specification for the single-example endpoint, documenting successful, conflict, and service-unavailable responses.
  * Added response schemas and metadata, including the hand-edited conflict model.

* **Tests**
  * Added coverage confirming request recording preserves manually edited API documentation and response definitions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->